### PR TITLE
generalize skfem.models.poisson.laplace to arbitrary dimension

### DIFF
--- a/examples/ex09.py
+++ b/examples/ex09.py
@@ -7,6 +7,7 @@ iterative methods.
 """
 from skfem import *
 from skfem.models.poisson import *
+import numpy as np
 
 p = np.linspace(0, 1, 16)
 m = MeshHex.init_tensor(p, p, p)

--- a/skfem/models/poisson.py
+++ b/skfem/models/poisson.py
@@ -7,12 +7,7 @@ from skfem.assembly import bilinear_form, linear_form
 
 @bilinear_form
 def laplace(u, du, v, dv, w):
-    if du.shape[0] == 2:
-        return du[0]*dv[0] + du[1]*dv[1]
-    elif du.shape[0] == 3:
-        return du[0]*dv[0] + du[1]*dv[1] + du[2]*dv[2]
-    else:
-        raise NotImplementedError("Laplace weakform not implemented for the used dimension.")
+    return sum(du[k]*dv[k] for k in range(du.shape[0]))
 
 @bilinear_form
 def mass(u, du, v, dv, w):

--- a/skfem/models/poisson.py
+++ b/skfem/models/poisson.py
@@ -6,7 +6,7 @@ from skfem.assembly import bilinear_form, linear_form
 
 @bilinear_form
 def laplace(u, du, v, dv, w):
-    return sum(du[k]*dv[k] for k in range(du.shape[0]))
+    return sum(du*dv)
 
 @bilinear_form
 def mass(u, du, v, dv, w):

--- a/skfem/models/poisson.py
+++ b/skfem/models/poisson.py
@@ -2,7 +2,6 @@
 """
 Poisson equation
 """
-import numpy as np
 from skfem.assembly import bilinear_form, linear_form
 
 @bilinear_form


### PR DESCRIPTION
The one-dimensional case is missing from skfem.models.poisson.laplace; rather than adding another special case, here's a generic approach that handles arbitrary dimension.

I thought that there might have been a more idiomatic way to write this in numpy ([`einsum`](https://docs.scipy.org/doc/numpy/reference/generated/numpy.einsum.html#numpy.einsum)?) but couldn't find it.