### PR TITLE
fix MeshQuad.plot for nodal functions

### DIFF
--- a/skfem/mesh.py
+++ b/skfem/mesh.py
@@ -968,7 +968,10 @@ class MeshQuad(Mesh2D):
         used.
 
         """
-        m, z = self._splitquads(z)
+        if len(z) == self.t.shape[-1]:
+            m, z = self._splitquads(z)
+        else:
+            m = self._splitquads()
         return m.plot(z, smooth, ax=ax, zlim=zlim, edgecolors=edgecolors)
 
     def plot3(self, z, smooth=False, ax=None):


### PR DESCRIPTION
As described in #32 , MeshQuad.plot passes the function onto `self._splitquads` even if it isn't defined elementally.  This incorporates the makeshift discussed there into the source, only splitting the function if elemental; the split mesh has the same nodes as the original, so the nodal function can be kept as is.
