### PR TITLE
makeshift -format msh2 for Gmsh 4

### DIFF
--- a/examples/ex13.py
+++ b/examples/ex13.py
@@ -46,7 +46,7 @@ geom.add_physical_surface(
     geom.add_plane_surface(geom.add_line_loop(lines)), 'domain')
 
 pts, cells, _, cell_data, field_data = generate_mesh(
-    geom, prune_vertices=False)
+    geom, prune_vertices=False, extra_gmsh_arguments=['-format', 'msh2'])
 
 mesh = MeshTri(pts[:, :2].T, cells['triangle'].T)
 boundaries = {bc:


### PR DESCRIPTION
This fixes #40 if the Gmsh on `$PATH` is version 4 but doesn't break it for older Gmsh either.

With this, ex13 passes, whereas without it it raises `KeyError` for `"gmsh:physicals"` for new Gmsh.

It should be possible to revert this once nschloe/meshio#289 is complete.

