### PR TITLE
meshio now reads physical tags so pygmsh.generate_mesh and Mesh.load work again

### DIFF
--- a/examples/ex13.py
+++ b/examples/ex13.py
@@ -46,7 +46,7 @@ geom.add_physical_surface(
     geom.add_plane_surface(geom.add_line_loop(lines)), 'domain')
 
 pts, cells, _, cell_data, field_data = generate_mesh(
-    geom, prune_vertices=False, extra_gmsh_arguments=['-format', 'msh2'])
+    geom, prune_vertices=False)
 
 mesh = MeshTri(pts[:, :2].T, cells['triangle'].T)
 boundaries = {bc:


### PR DESCRIPTION
With nschloe/meshio#304 , meshio.read now reads the physical tags for Gmsh 4's new default format MSH4 (as well as still from Gmsh 3's legacy default format MSH2).

This means that examples using `pygmsh.generate_mesh` which calls `meshio.read` internally no longer need to specify the legacy default format so as to work with the current stable Gmsh installed.  This is seen as a cleaner fix of #40 than the makeshift #42.

It also means that `skfem.Mesh.load`,  also based on `meshio.read`, will work on MSH4, fixing #41.