### PR TITLE
demonstrate use of submesh to calculate boundary flux

### DIFF
--- a/examples/ex13.py
+++ b/examples/ex13.py
@@ -69,3 +69,5 @@ print('conductance = {:.4f} (exact = 2 ln 2 / pi = {:.4f})'.format(
 
 mesh.plot(u)
 mesh.show()
+
+positive_basis = FacetBasis(mesh, elements, submesh=mesh.boundaries['positive'])

--- a/examples/ex13.py
+++ b/examples/ex13.py
@@ -67,7 +67,14 @@ print('L2 error =', np.sqrt(u_error @ asm(mass, basis) @ u_error))
 print('conductance = {:.4f} (exact = 2 ln 2 / pi = {:.4f})'.format(
     u @ A @ u, 2 * np.log(2) / np.pi))
 
+@linear_form
+def port_flux(v, dv, w):
+    return sum(w.n * dv)
+
+for port in mesh.boundaries:
+    basis = FacetBasis(mesh, elements, submesh=mesh.boundaries[port])
+    form = asm(port_flux, basis)
+    print('Current in through {} = {:.4f}'.format(port, form @ u))
+
 mesh.plot(u)
 mesh.show()
-
-positive_basis = FacetBasis(mesh, elements, submesh=mesh.boundaries['positive'])

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -1,5 +1,4 @@
 import unittest
-import numpy as np
 from skfem.mesh import *
 
 class MeshTests(unittest.TestCase):

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -1,4 +1,5 @@
 import unittest
+import numpy as np
 from skfem.mesh import *
 
 class MeshTests(unittest.TestCase):


### PR DESCRIPTION
This demonstrates the solution of how to compute the flux through a part of the boundary #49 by extending `examples/ex13.py`, where the conductance had already been calculated independently from the areal integral of the dissipation.