### PR TITLE
WIP: first Stokes-flow example

### DIFF
--- a/examples/biharmonic.py
+++ b/examples/biharmonic.py
@@ -65,7 +65,7 @@ def unit_rotation(v, dv, ddv, w):
 
 
 stokes = asm(biharmonic, ib)
-rotf = -asm(unit_rotation, ib)
+rotf = asm(unit_rotation, ib)
 
 dofs = ib.get_dofs(mesh.boundaries['perimeter'])
 
@@ -80,8 +80,11 @@ if __name__ == "__main__":
     from sys import argv
 
     from matplotlib.tri import Triangulation
-
+    
     M, Psi = ib.refinterp(psi, 3)
+    Psi0 = max(Psi)
+    print('ψ0 = {} (cf. exact = 1/64 ≐ {})'.format(Psi0, 1/64))
+
     ax = mesh.draw()
     ax.tricontour(Triangulation(M.p[0, :], M.p[1, :], M.t.T), Psi)
     ax.axis('off')

--- a/examples/biharmonic.py
+++ b/examples/biharmonic.py
@@ -1,16 +1,23 @@
-"""The stream-function ψ for two-dimensional incompressible creeping flow 
+"""The stream-function :math:`\psi` for two-dimensional creeping flow 
 
-is governed by the biharmonic equation, ν Δ²ψ = rot f, where ν is the
-kinematic viscosity, f the volumetric body-force, and rot f = (∂f/∂y,
--∂f/∂x).  The boundary conditions at a wall are that ψ be constant
-(the wall is impermeable) and that the normal component of its
-gradient vanish (no slip).  Thus the boundary value problem is
-analogous to that of bending a plate, and may be treated with Morley
-elements as in ex10.
+is governed by the biharmonic equation
 
-Here consider a buoyancy force f = (0, x), which arises in the
+.. math::  
+    \nu \Delta^2\psi = \mathop{rot} f
+
+where :math:`\nu` is the kinematic viscosity (assumed constant),
+:math:`f` the volumetric body-force, and :math:`\mathop{rot} f =
+(\partial f/\partial y, -\partial f/\partial x)`.  The boundary
+conditions at a wall are that :math:`\psi` be constant (the wall is
+impermeable) and that the normal component of its gradient vanish (no
+slip).  Thus the boundary value problem is analogous to that of
+bending a clamped plate, and may be treated with Morley elements as in
+`ex10`.
+
+Here consider a buoyancy force :math:`f = x\jhat`, which arises in the
 Boussinesq approximation of natural convection with a horizontal
-temperature gradient.
+temperature gradient (`Batchelor 1954`
+<http://dx.doi.org/10.1090/qam/64563>`_).
 
 For a circular cavity, the problem admits a polynomial solution with
 circular stream-lines.
@@ -19,7 +26,6 @@ circular stream-lines.
 
 from skfem import *
 
-from matplotlib.tri import Triangulation
 import numpy as np
 
 import meshio
@@ -72,6 +78,8 @@ if __name__ == "__main__":
 
     from os.path import splitext
     from sys import argv
+
+    from matplotlib.tri import Triangulation
 
     M, Psi = ib.refinterp(psi, 3)
     ax = mesh.draw()

--- a/examples/biharmonic.py
+++ b/examples/biharmonic.py
@@ -89,6 +89,21 @@ if __name__ == "__main__":
     print('ψ0 = {} (cf. exact = 1/64 ≐ {})'.format(Psi0, 1/64))
 
     ax = mesh.draw()
+    ax.set_title('stream-lines')
+    fig = ax.get_figure()
     ax.tricontour(Triangulation(M.p[0, :], M.p[1, :], M.t.T), Psi)
     ax.axis('off')
-    ax.get_figure().savefig(splitext(argv[0])[0] + '.png')
+    ax.get_figure().savefig(splitext(argv[0])[0] + '-stream-lines.png')
+
+    refbasis = InteriorBasis(M, ElementTriP1())
+    velocity = np.vstack([derivative(Psi, refbasis, refbasis, 1),
+                          -derivative(Psi, refbasis, refbasis, 0)])
+    ax = mesh.draw()
+    ax.set_title('velocity vectors coloured by buoyancy')
+    sparsity_factor = 2**3      # subsample the arrows
+    vector_factor = 2**3        # lengthen the arrows
+    x = M.p[:, ::sparsity_factor]
+    u = vector_factor * velocity[:, ::sparsity_factor]
+    ax.quiver(x[0], x[1], u[0], u[1], x[0])
+    ax.axis('off')
+    ax.get_figure().savefig(splitext(argv[0])[0] + '-velocity-vectors.png')

--- a/examples/biharmonic.py
+++ b/examples/biharmonic.py
@@ -1,0 +1,80 @@
+"""The stream-function ψ for two-dimensional incompressible creeping flow 
+
+is governed by the biharmonic equation, ν Δ²ψ = rot f, where ν is the
+kinematic viscosity, f the volumetric body-force, and rot f = (∂f/∂y,
+-∂f/∂x).  The boundary conditions at a wall are that ψ be constant
+(the wall is impermeable) and that the normal component of its
+gradient vanish (no slip).  Thus the boundary value problem is
+analogous to that of bending a plate, and may be treated with Morley
+elements as in ex10.
+
+Here consider a buoyancy force f = (0, x), which arises in the
+Boussinesq approximation of natural convection with a horizontal
+temperature gradient.
+
+For a circular cavity, the problem admits a polynomial solution with
+circular stream-lines.
+
+"""
+
+from skfem import *
+
+from matplotlib.tri import Triangulation
+import numpy as np
+
+import meshio
+from pygmsh import generate_mesh
+from pygmsh.built_in import Geometry
+
+geom = Geometry()
+circle = geom.add_circle([0.] * 3, 1., .5**3)
+geom.add_physical_line(circle.line_loop.lines, 'perimeter')
+geom.add_physical_surface(circle.plane_surface, 'disk')
+mesh = MeshTri.from_meshio(meshio.Mesh(*generate_mesh(geom)))
+
+element = ElementTriMorley()
+mapping = MappingAffine(mesh)
+ib = InteriorBasis(mesh, element, mapping, 2)
+
+
+@bilinear_form
+def biharmonic(u, du, ddu, v, dv, ddv, w):
+
+    def shear(ddw):
+        return np.array([[ddw[0][0], ddw[0][1]],
+                         [ddw[1][0], ddw[1][1]]])
+
+    def ddot(T1, T2):
+        return T1[0, 0]*T2[0, 0] +\
+               T1[0, 1]*T2[0, 1] +\
+               T1[1, 0]*T2[1, 0] +\
+               T1[1, 1]*T2[1, 1]
+
+    return ddot(shear(ddu), shear(ddv))
+
+
+@linear_form
+def unit_rotation(v, dv, ddv, w):
+    return v
+
+
+stokes = asm(biharmonic, ib)
+rotf = -asm(unit_rotation, ib)
+
+dofs = ib.get_dofs(mesh.boundaries['perimeter'])
+
+D = np.concatenate((dofs.nodal['u'], dofs.facet['u_n']))
+
+psi = np.zeros_like(rotf)
+psi[ib.complement_dofs(D)] = solve(*condense(stokes, rotf, D=D))
+
+if __name__ == "__main__":
+
+    from os.path import splitext
+    from sys import argv
+
+    M, Psi = ib.refinterp(psi, 3)
+    ax = mesh.draw()
+    ax.tricontour(Triangulation(M.p[0, :], M.p[1, :], M.t.T), Psi)
+    ax.axis('off')
+    ax.get_figure().savefig(splitext(argv[0])[0] + '.png')

--- a/examples/biharmonic.py
+++ b/examples/biharmonic.py
@@ -23,7 +23,7 @@ For a circular cavity of radius :math:`a`, the problem admits a
 polynomial solution with circular stream-lines:
 
 .. math::
-    \psi = \left\{1 - (x^2+y^2)/a^2\right\} / 64.
+    \psi = \left\{1 - (x^2+y^2)/a^2\right\}^2 / 64.
 
 """
 

--- a/examples/biharmonic.py
+++ b/examples/biharmonic.py
@@ -19,8 +19,11 @@ Boussinesq approximation of natural convection with a horizontal
 temperature gradient (`Batchelor 1954`
 <http://dx.doi.org/10.1090/qam/64563>`_).
 
-For a circular cavity, the problem admits a polynomial solution with
-circular stream-lines.
+For a circular cavity of radius :math:`a`, the problem admits a
+polynomial solution with circular stream-lines:
+
+.. math::
+    \psi = \left\{1 - (x^2+y^2)/a^2\right\} / 64.
 
 """
 


### PR DESCRIPTION
Here's a start on one of the hydrodynamic examples proposed in #31.

It builds on ex02 (plate), ex12 (pygmsh disk), and ex13 (pygmsh boundaries).  What's new is an apppropriately simplified biharmonic operator and the use of `tricontour` to extract the stream-lines.

