### PR TITLE
don't embed 2d points in (yz-plane of) 3d, fixes #60

### DIFF
--- a/skfem/mesh/mesh2d/mesh2d.py
+++ b/skfem/mesh/mesh2d/mesh2d.py
@@ -188,9 +188,6 @@ class Mesh2D(Mesh):
         """
         import meshio
 
-        # a row of zeros required in 2D
-        p = np.vstack((np.zeros(self.p.shape[1]), self.p))
-
         if pointData is not None:
             if type(pointData) != dict:
                 pointData = {'0':pointData}
@@ -200,7 +197,7 @@ class Mesh2D(Mesh):
                 cellData = {'0':cellData}
 
         cells = { self.meshio_type : self.t.T }
-        mesh = meshio.Mesh(p.T, cells, pointData, cellData)
+        mesh = meshio.Mesh(self.p.T, cells, pointData, cellData)
         meshio.write(filename, mesh)
 
     def param(self) -> float:


### PR DESCRIPTION
Calling `Mesh2d.save` used to embed the points in the _yz_-plane #60; however, skipping this (as implemented here) lets `meshio.write` embed the points in the _xy_-plane for VTK output (three dimensions being required by that format) or output valid two-dimensional meshes in formats that allow that, e.g. MEDIT mesh.  

`meshio.vtk_io.write` does emit a warning
> WARNING:root:VTK requires 3D points, but 2D points given. Appending 0 third component.

but it's harmless.
