### PR TITLE
re-solve side-heated circular cavity with Taylor-Hood

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,12 @@
+name: scikit-fem-dev
+dependencies:
+  - python=3.7
+  - numpy
+  - scipy
+  - matplotlib
+  - ipython
+  - sphinx
+  - pip:
+    - meshio
+    - pygmsh
+    - sphinx_rtd_theme

--- a/examples/taylor_hood.py
+++ b/examples/taylor_hood.py
@@ -1,3 +1,28 @@
+"""This solves for the same creeping flow as ex18 in primitive variables,
+
+i.e. velocity and pressure instead of stream-function.  These are governed by
+the Stokes momentum
+
+.. math::
+    0 = -\rho^{-1}\nabla p + \mathbf f \nu\Delta\mathbf u
+
+and continuity equations
+
+.. math::
+    \nabla\mathbf u = 0.
+
+This is an example of a mixed problem because it contains two
+different kinds of unknowns; pairs of elements for them have to be
+chosen carefully.  One of the simplest workable choices is the
+Taylor--Hood element: `ElementVectorH1(ElementTriP2())` for velocity
+and `ElementTriP1()` for pressure.
+
+This example also demonstrates the use of the external pure-Python
+`dmsh` to generate a `MeshTri`.
+
+"""
+
+
 from skfem import *
 from skfem.models.poisson import vector_laplace, mass
 from skfem.models.general import divergence

--- a/examples/taylor_hood.py
+++ b/examples/taylor_hood.py
@@ -4,12 +4,12 @@ i.e. velocity and pressure instead of stream-function.  These are governed by
 the Stokes momentum
 
 .. math::
-    0 = -\rho^{-1}\nabla p + \mathbf f + \nu\Delta\mathbf u
+    0 = -\rho^{-1}\nabla p + \boldsymbol{f} + \nu\Delta\boldsymbol{u}
 
 and continuity equations
 
 .. math::
-    \nabla\mathbf u = 0.
+    \nabla\cdot\boldsymbol{u} = 0.
 
 This is an example of a mixed problem because it contains two
 different kinds of unknowns; pairs of elements for them have to be
@@ -24,12 +24,11 @@ Once the velocity has been found, the stream-function :math:`\psi` can
 be calculated by solving the Poisson problem
 
 .. math::
-    -\Delta\psi = \mathbf k\cdot\nabla\times\mathbf u
+    -\Delta\psi = \mathrm{rot} \boldsymbol{u}. 
 
-where :math:`\mathbf k` is the unit-vector out of the plane.  The
-boundary conditions are that the stream-function be constant around
-the impermeable perimeter; this constant can be taken as zero without
-loss of generality.  In the weak formulation
+The boundary conditions are that the stream-function be constant
+around the impermeable perimeter; this constant can be taken as zero
+without loss of generality.  In the weak formulation
 
 .. math::
     \left(\nabla\phi, \nabla\psi\right) = \left(\phi\mathbf k, \nabla\times\mathbf u\right)

--- a/examples/taylor_hood.py
+++ b/examples/taylor_hood.py
@@ -1,5 +1,5 @@
 from skfem import *
-from skfem.models.poisson import mass
+from skfem.models.poisson import vector_laplace, mass
 
 import numpy as np
 from scipy.sparse import bmat
@@ -21,11 +21,6 @@ basis = {variable: InteriorBasis(mesh, e, intorder=3)
 
 
 @bilinear_form
-def vector_laplacian(u, du, v, dv, w):
-    return np.einsum('ij...,ij...', du, dv)
-
-
-@bilinear_form
 def dilatation(u, du, q, dq, w):
     return (du[0][0] + du[1][1]) * q
 
@@ -35,7 +30,7 @@ def body_force(v, dv, w):
     return w.x[0] * v[1]
 
 
-A = asm(vector_laplacian, basis['u'])
+A = asm(vector_laplace, basis['u'])
 B = asm(dilatation, basis['u'], basis['p'])
 C = asm(mass, basis['p'])
 

--- a/examples/taylor_hood.py
+++ b/examples/taylor_hood.py
@@ -24,20 +24,25 @@ Once the velocity has been found, the stream-function :math:`\psi` can
 be calculated by solving the Poisson problem
 
 .. math::
-    -\Delta\psi = \mathrm{rot} \boldsymbol{u}. 
+    -\Delta\psi = \mathrm{rot} \boldsymbol{u}.
 
 The boundary conditions are that the stream-function be constant
 around the impermeable perimeter; this constant can be taken as zero
 without loss of generality.  In the weak formulation
 
 .. math::
-    \left(\nabla\phi, \nabla\psi\right) = \left(\phi\mathbf k, \nabla\times\mathbf u\right)
+    \left(\nabla\phi, \nabla\psi\right) = \left(\phi, \mathrm{rot}\boldsymbol{u}\right)
 
 the right-hand side can be converted using Green's theorem and the
 no-slip condition to not involve the derivatives of the velocity:
 
 .. math::
-     \left(\phi\mathbf k, \nabla\times\mathbf u\right) = \left(\mathbf k\times\nabla\phi, \mathbf u\right).
+     \left(\phi, \mathrm{rot}\boldsymbol{u}\right) = \left(\boldsymbol{rot}\phi, \boldsymbol{u}\right)
+
+where :math:`\boldmath{rot}` is the adjoint of :math:`\mathrm{rot}`:
+
+.. math::
+    \boldsymbol{rot}\phi \equiv \frac{\partial\phi}{\partial y}\hat{i} - \frac{\partial\phi}{\partial x}\hat{j}.
 
 """
 

--- a/examples/taylor_hood.py
+++ b/examples/taylor_hood.py
@@ -1,5 +1,6 @@
 from skfem import *
 from skfem.models.poisson import vector_laplace, mass
+from skfem.models.general import divergence
 
 import numpy as np
 from scipy.sparse import bmat
@@ -20,18 +21,13 @@ basis = {variable: InteriorBasis(mesh, e, intorder=3)
          for variable, e in element.items()}
 
 
-@bilinear_form
-def dilatation(u, du, q, dq, w):
-    return (du[0][0] + du[1][1]) * q
-
-
 @linear_form
 def body_force(v, dv, w):
     return w.x[0] * v[1]
 
 
 A = asm(vector_laplace, basis['u'])
-B = asm(dilatation, basis['u'], basis['p'])
+B = asm(divergence, basis['u'], basis['p'])
 C = asm(mass, basis['p'])
 
 K = bmat([[A, B.T],

--- a/examples/taylor_hood.py
+++ b/examples/taylor_hood.py
@@ -1,4 +1,5 @@
 from skfem import *
+from skfem.models.poisson import mass
 
 import numpy as np
 from scipy.sparse import bmat
@@ -29,11 +30,6 @@ def dilatation(u, du, q, dq, w):
     return (du[0][0] + du[1][1]) * q
 
 
-@bilinear_form
-def regularization(p, dp, q, dq, w):
-    return p * q
-
-
 @linear_form
 def body_force(v, dv, w):
     return w.x[0] * v[1]
@@ -41,7 +37,7 @@ def body_force(v, dv, w):
 
 A = asm(vector_laplacian, basis['u'])
 B = asm(dilatation, basis['u'], basis['p'])
-C = asm(dilatation, basis['p'])
+C = asm(mass, basis['p'])
 
 K = bmat([[A, B.T],
           [B, 1e-3 * C]]).tocsr()

--- a/examples/taylor_hood.py
+++ b/examples/taylor_hood.py
@@ -4,7 +4,7 @@ i.e. velocity and pressure instead of stream-function.  These are governed by
 the Stokes momentum
 
 .. math::
-    0 = -\rho^{-1}\nabla p + \mathbf f \nu\Delta\mathbf u
+    0 = -\rho^{-1}\nabla p + \mathbf f + \nu\Delta\mathbf u
 
 and continuity equations
 

--- a/examples/taylor_hood.py
+++ b/examples/taylor_hood.py
@@ -82,7 +82,7 @@ f = np.concatenate([asm(body_force, basis['u']),
 
 boundary = mesh.submesh(boundaries_only=True)
 dofs = basis['u'].get_dofs(boundary)
-D = np.concatenate((dofs.nodal['u^1'], dofs.nodal['u^2']))
+D = dofs.all()
 uvp = np.zeros(K.shape[0])
 uvp[np.setdiff1d(np.arange(K.shape[0]), D)] = solve(*condense(K, f, D=D))
 

--- a/examples/taylor_hood.py
+++ b/examples/taylor_hood.py
@@ -20,6 +20,26 @@ and `ElementTriP1()` for pressure.
 This example also demonstrates the use of the external pure-Python
 `dmsh` to generate a `MeshTri`.
 
+Once the velocity has been found, the stream-function :math:`\psi` can
+be calculated by solving the Poisson problem
+
+.. math::
+    -\Delta\psi = \mathbf k\cdot\nabla\times\mathbf u
+
+where :math:`\mathbf k` is the unit-vector out of the plane.  The
+boundary conditions are that the stream-function be constant around
+the impermeable perimeter; this constant can be taken as zero without
+loss of generality.  In the weak formulation
+
+.. math::
+    \left(\nabla\phi, \nabla\psi\right) = \left(\phi\mathbf k, \nabla\times\mathbf u\right)
+
+the right-hand side can be converted using Green's theorem and the
+no-slip condition to not involve the derivatives of the velocity:
+
+.. math::
+     \left(\phi\mathbf k, \nabla\times\mathbf u\right) = \left(\mathbf k\times\nabla\phi, \mathbf u\right).
+
 """
 
 

--- a/examples/taylor_hood.py
+++ b/examples/taylor_hood.py
@@ -96,7 +96,7 @@ def rot(v, dv, w):
 basis['psi'] = InteriorBasis(mesh, ElementTriP2())
 A = asm(laplace, basis['psi'])
 psi = np.zeros(A.shape[0])
-D = basis['psi'].get_dofs(boundary).nodal['u']
+D = basis['psi'].get_dofs(boundary).all()
 interior = basis['psi'].complement_dofs(D)
 psi[D] = 0.
 vorticity = asm(rot, basis['psi'],

--- a/examples/taylor_hood.py
+++ b/examples/taylor_hood.py
@@ -55,3 +55,11 @@ velocity, pressure = np.split(uvp, [A.shape[0]])
 ax = mesh.plot(pressure)
 ax.axis('off')
 ax.get_figure().savefig('taylor_hood_pressure.png')
+
+ax = mesh.draw()
+velocity1 = velocity[basis['u'].nodal_dofs]
+ax.quiver(mesh.p[0, :], mesh.p[1, :],
+          velocity1[0, :], velocity1[1, :],
+          mesh.p[0, :])         # colour by buoyancy
+ax.axis('off')
+ax.get_figure().savefig('taylor_hood_velocity.png')

--- a/skfem/models/general.py
+++ b/skfem/models/general.py
@@ -1,0 +1,11 @@
+"""
+Bilinear and linear forms too general to put into a specific model.
+"""
+from skfem.assembly import bilinear_form
+
+import numpy as np
+
+
+@bilinear_form
+def divergence(u, du, q, dq, w):
+    return np.einsum('ii...', du) * q

--- a/skfem/models/poisson.py
+++ b/skfem/models/poisson.py
@@ -4,9 +4,15 @@ Poisson equation
 """
 from skfem.assembly import bilinear_form, linear_form
 
+import numpy as np
+
 @bilinear_form
 def laplace(u, du, v, dv, w):
     return sum(du*dv)
+
+@bilinear_form
+def vector_laplace(u, du, v, dv, w):
+    return np.einsum('ij...,ij...', du, dv)
 
 @bilinear_form
 def mass(u, du, v, dv, w):


### PR DESCRIPTION
This follows overnight discussion of Taylor-Hood on Gitter.

Indeed, P2-P1 is much easier than Q2-P1 since then both variables share the same mesh.

So far only the pressure is plotted; being scalar and P1 this is easy with current facilities.  The exact answer is that the isobars should be rectangular hyperbolae, i.e. level-sets of _xy_.  This looks about right.

For further details of exact solution, see 
* G. D. McBain 2016 Creeping convection in a horizontally heated ellipsoid. In _Proceedings of the Twentieth Australasian Fluid Mechanics Conference,_ Paper 548. ([PDF](http://people.eng.unimelb.edu.au/imarusic/proceedings/20/548%20Paper.pdf))