### PR TITLE
use Mesh.subdomains in defining coefficients piecewise

### DIFF
--- a/docs/examples/insulated.py
+++ b/docs/examples/insulated.py
@@ -66,8 +66,7 @@ conductivity = basis.zero_w()
 for subdomain, elements in mesh.subdomains.items():
     conductivity[elements] = thermal_conductivity[subdomain]
 
-L = asm(conduction, basis,
-        w=conductivity)
+L = asm(conduction, basis, w=conductivity)
 
 facet_basis = FacetBasis(mesh, element, facets=mesh.boundaries['convection'])
 H = heat_transfer_coefficient * asm(convection, facet_basis)

--- a/skfem/assembly/global_basis/global_basis.py
+++ b/skfem/assembly/global_basis/global_basis.py
@@ -223,3 +223,12 @@ class GlobalBasis():
                                    * self.basis[1][j][a]
             return W, dW
         return W
+
+    def zero_w(self) -> ndarray:
+        """Return a zero array with correct dimensions
+
+        for :func:`~skfem.assembly.asm`.
+
+        """
+
+        return np.zeros((self.nelems, len(self.W)))


### PR DESCRIPTION
This takes up the two suggestions from #95.  Besides that in the title, also introducing a method for `GlobalBasis` to set up an elements × abscissæ array of weights, but called `zero_w` rather than `empty_w` since it uses `zeros` rather than `empty` because sometimes (e.g. in constructing an indicator array) the zeros are left as zeros.