### PR TITLE
upgrade ex12, 13 from P1 to P2

### DIFF
--- a/docs/examples/ex12.py
+++ b/docs/examples/ex12.py
@@ -43,7 +43,8 @@ basis = InteriorBasis(m, e, map, 2)
 A = asm(laplace, basis)
 b = asm(unit_load, basis)
 
-I = m.interior_nodes()
+D = basis.get_dofs().all()
+I = basis.complement_dofs(D)
 
 x = 0*b
 x[I] = solve(*condense(A, b, I=I))

--- a/docs/examples/ex12.py
+++ b/docs/examples/ex12.py
@@ -36,7 +36,7 @@ geom.add_physical_surface(geom.add_circle([0.] * 3, 1., .5**3).plane_surface,
 points, cells = generate_mesh(geom)[:2]
 m = MeshTri(points[:, :2].T, cells['triangle'].T)
 
-e = ElementTriP1()
+e = ElementTriP2()
 map = MappingAffine(m)
 basis = InteriorBasis(m, e, map, 2)
 
@@ -58,5 +58,5 @@ if __name__ == '__main__':
     print('k = {:.5f} (exact = 1/8/pi = {:.5f})'.format(k, 1/np.pi/8))
     print("k' = {:.5f} (exact = 1/4/pi = {:.5f})".format(k1, 1/np.pi/4))
 
-    m.plot3(x)
+    m.plot3(x[basis.nodal_dofs.flatten()])
     m.show()

--- a/docs/examples/ex12.py
+++ b/docs/examples/ex12.py
@@ -36,9 +36,7 @@ geom.add_physical_surface(geom.add_circle([0.] * 3, 1., .5**3).plane_surface,
 points, cells = generate_mesh(geom)[:2]
 m = MeshTri(points[:, :2].T, cells['triangle'].T)
 
-e = ElementTriP2()
-map = MappingAffine(m)
-basis = InteriorBasis(m, e, map, 2)
+basis = InteriorBasis(m, ElementTriP2())
 
 A = asm(laplace, basis)
 b = asm(unit_load, basis)

--- a/docs/examples/ex13.py
+++ b/docs/examples/ex13.py
@@ -50,7 +50,7 @@ mesh = MeshTri.from_meshio(meshio.Mesh(*generate_mesh(geom,
                                                       prune_vertices=False)))
 
 elements = ElementTriP2()
-basis = InteriorBasis(mesh, elements, MappingAffine(mesh), 2)
+basis = InteriorBasis(mesh, elements)
 A = asm(laplace, basis)
 
 boundary_dofs = basis.get_dofs(mesh.boundaries)

--- a/docs/examples/ex13.py
+++ b/docs/examples/ex13.py
@@ -81,5 +81,5 @@ for port in mesh.boundaries:
     form = asm(port_flux, basis)
     print('Current in through {} = {:.4f}'.format(port, form @ u))
 
-mesh.plot(u[:mesh.p.shape[1]])
+mesh.plot(u[basis.nodal_dofs.flatten()])
 mesh.show()


### PR DESCRIPTION
While thinking about #112 and #84, I generalized a couple of the Poisson examples so that they could use either ElementTriP1 or ElementTriP2, without other modification.  The issues here all  stem from #84: that one doesn't know the coordinate-locations corresponding to the nonnodal degrees of freedom in the quadratic elements.