### PR TITLE
use __file__ to work out where to load mesh from

### DIFF
--- a/docs/examples/ex21.py
+++ b/docs/examples/ex21.py
@@ -3,7 +3,9 @@ from skfem.models.elasticity import linear_elasticity,\
                                     lame_parameters
 import numpy as np
 
-m = MeshTet.load("docs/examples/beams.msh")
+from pathlib import Path
+
+m = MeshTet.load(str(Path(__file__).with_name("beams.msh")))
 e1 = ElementTetP1()
 e = ElementVectorH1(e1)
 


### PR DESCRIPTION
To load a mesh from a file for an example, specifying the path can be tricky.  The following

https://github.com/kinnala/scikit-fem/blob/7dbe3cbc6f1e11188d72337a1e4577a4f8a1cbaa/docs/examples/ex21.py#L6

only works if the example is run from the top-level directory as
```shell
python docs/examples/ex21.py
```

but of course failed when I ran it in `docs/examples`.

There are facilities in the standard library for getting around this.  The one adopted here might even work on non-POSIX systems.
