### PR TITLE
no longer need to pad 2d vectors for VTK

### DIFF
--- a/docs/examples/backward_facing_step.py
+++ b/docs/examples/backward_facing_step.py
@@ -122,9 +122,7 @@ if __name__ == '__main__':
     ax.get_figure().savefig(f'{name}-pressure.png',
                             bbox_inches='tight', pad_inches=0)
 
-    mesh.save(f'{name}-velocity.vtk',
-              np.pad(velocity[basis['u'].nodal_dofs],
-                     ((0, 1), (0, 0)), 'constant').T)  # meshio#325
+    mesh.save(f'{name}-velocity.vtk', velocity[basis['u'].nodal_dofs].T)
     
     fig, ax = subplots()
     ax.plot(

--- a/docs/examples/ex18.py
+++ b/docs/examples/ex18.py
@@ -61,10 +61,7 @@ if __name__ == '__main__':
 
     name = splitext(argv[0])[0]
 
-    mesh.save(f'{name}_velocity.vtk',
-              np.vstack([velocity[basis['u'].nodal_dofs],
-                         np.zeros_like(mesh.p[0])]).T)
-
+    mesh.save(f'{name}_velocity.vtk', velocity[basis['u'].nodal_dofs].T)
     
     print(basis['psi'].interpolator(psi)(np.zeros((2, 1)))[0],
           '(cf. exact 1/64)')


### PR DESCRIPTION
2d vectors are now padded upstream by nschloe/meshio#326, so it's no longer necessary to do so explicitly in a scikit-fem script.

This fixes #123.  (Except for the XDMF part, but that's pending nschloe/meshio#327.)
