### PR TITLE
pass *args, **kwargs on from Mesh.savefig to matplotlib.pyplot.savefig

### DIFF
--- a/docs/examples/ex24.py
+++ b/docs/examples/ex24.py
@@ -102,9 +102,8 @@ if __name__ == '__main__':
 
     name = splitext(argv[0])[0]
     
-    ax = mesh.plot(pressure)
-    ax.get_figure().savefig(f'{name}-pressure.png',
-                            bbox_inches='tight', pad_inches=0)
+    mesh.plot(pressure)
+    mesh.savefig(f'{name}-pressure.png', bbox_inches='tight', pad_inches=0)
 
     mesh.save(f'{name}-velocity.vtk', velocity[basis['u'].nodal_dofs].T)
     

--- a/skfem/mesh/mesh.py
+++ b/skfem/mesh/mesh.py
@@ -92,9 +92,9 @@ class Mesh():
         """A wrapper for matplotlib.pyplot.show()."""
         plt.show()
 
-    def savefig(self, path):
+    def savefig(self, *args, **kwargs):
         """A wrapper for matplotlib.pyplot.savefig()."""
-        plt.savefig(path)
+        plt.savefig(*args, **kwargs)
 
     def dim(self):
         """Return the spatial dimension of the mesh."""


### PR DESCRIPTION
https://github.com/kinnala/scikit-fem/blob/c8ad891eb94532aa51bd634b6bd9a05622f81400/docs/examples/ex24.py#L105-L107

could have used [`Mesh.savefig`](https://github.com/kinnala/scikit-fem/blob/master/skfem/mesh/mesh.py#L95), except that the latter doesn't pass on its arguments.