### PR TITLE
documented use of numerical continuation for Bratu–Gelfand

### DIFF
--- a/docs/examples/ex23.py
+++ b/docs/examples/ex23.py
@@ -48,7 +48,7 @@ class Bratu1d():
 
     def jacobian_solver(self,
                         u: np.ndarray,
-                        lmbda: np.ndarray,
+                        lmbda: float,
                         rhs: np.ndarray) -> np.ndarray:
         """A solver for the Jacobian problem."""
         du = np.zeros_like(u)

--- a/docs/examples/ex23.rst
+++ b/docs/examples/ex23.rst
@@ -5,15 +5,13 @@ Bratu-Gelfand
 
    This example requires the external package `pacopy <https://github.com/nschloe/pacopy>`_
 
-Bifurcation diagram for Bratu–Gelfand two-point boundary value problem:
+Here the bifurcation diagram for the Bratu–Gelfand two-point boundary value problem is reproduced by numerical continuation as implemented in pacopy, and adapted from the pacopy example `Bratu <https://github.com/nschloe/pacopy/blob/master/README.md#bratu>`_.
 
 .. math::
 
     u'' + \lambda \mathrm e^u = 0, \quad 0 < x < 1,
 
 with :math:`u(0)=u(1)=0` and where :math:`\lambda > 0` is a parameter.
-
-Adapted from the example in the README.md of https://github.com/nschloe/pacopy.
 
 For treatment by numerical continuation, we define the residual
 

--- a/docs/examples/ex23.rst
+++ b/docs/examples/ex23.rst
@@ -50,7 +50,7 @@ The resulting bifurcation diagram, matches figure 1.1 (left) of Farrell, Birkiss
 .. figure:: ex23.png
 
 
-* P. E. Farrell, Á. Birkisson, & S. W. Funke (2015). Deflation techniques for finding distinct solutions of nonlinear partial differential equations. SIAM Journal on Scientific Computing 37(4). pp. A2026–A2045. `doi:10.1137/140984798 <http://dx.doi.org/10.1137/140984798>`_
+* P. E. Farrell, Á. Birkisson, & S. W. Funke (2015). Deflation techniques for finding distinct solutions of nonlinear partial differential equations. *SIAM Journal on Scientific Computing* 37(4). pp. A2026–A2045. `doi:10.1137/140984798 <http://dx.doi.org/10.1137/140984798>`_
   
 .. literalinclude:: ex23.py
    :linenos:

--- a/docs/examples/ex23.rst
+++ b/docs/examples/ex23.rst
@@ -50,7 +50,7 @@ The resulting bifurcation diagram, matches figure 1.1 (left) of Farrell, Birkiss
 .. figure:: ex23.png
 
 
-* P. E. Farrell, Á. Birkisson, & S. W. Funke (2015). Deflation techniques for finding distinct solutions of nonlinear partial differential equations. SIAM Journal on Scientific Computing 37(4). pp. A2026-A2045. `doi:10.1137/140984798 <http://dx.doi.org/10.1137/140984798>`_
+* P. E. Farrell, Á. Birkisson, & S. W. Funke (2015). Deflation techniques for finding distinct solutions of nonlinear partial differential equations. SIAM Journal on Scientific Computing 37(4). pp. A2026–A2045. `doi:10.1137/140984798 <http://dx.doi.org/10.1137/140984798>`_
   
 .. literalinclude:: ex23.py
    :linenos:

--- a/docs/examples/ex23.rst
+++ b/docs/examples/ex23.rst
@@ -19,7 +19,7 @@ For treatment by numerical continuation, we define the residual
 
 .. math::
 
-    F(u, \lambda) = u'' + \lambda \mathrm e^u
+    F(u, \lambda) = -u'' - \lambda \mathrm e^u
 
 .. literalinclude:: ex23.py
     :start-at: def f
@@ -39,7 +39,7 @@ and the Jacobian
 
 .. math::
 
-   J (u) = \frac{\mathrm d^2}{\mathrm dx^2} - \lambda \mathrm e^u
+   J (u) = -\frac{\mathrm d^2}{\mathrm dx^2} - \lambda \mathrm e^u
 
 .. literalinclude:: ex23.py
     :start-at: def jacobian_solver

--- a/docs/examples/ex23.rst
+++ b/docs/examples/ex23.rst
@@ -1,4 +1,4 @@
-Bratu-Gelfand
+Bratu–Gelfand
 -------------
 
 .. note::

--- a/docs/examples/ex23.rst
+++ b/docs/examples/ex23.rst
@@ -9,14 +9,46 @@ Bifurcation diagram for Bratu–Gelfand two-point boundary value problem:
 
 .. math::
 
-    u'' + \lambda e^u = 0, \quad 0 < x < 1,
+    u'' + \lambda \mathrm e^u = 0, \quad 0 < x < 1,
 
 with :math:`u(0)=u(1)=0` and where :math:`\lambda > 0` is a parameter.
 
 Adapted from the example in the README.md of https://github.com/nschloe/pacopy.
 
-The resulting diagram matches figure 1.1 (left) of Farrell, Birkisson,
-& Funke (2015).
+For treatment by numerical continuation, we define the residual
+
+.. math::
+
+    F(u, \lambda) = u'' + \lambda \mathrm e^u
+
+.. literalinclude:: ex23.py
+    :start-at: def f
+    :lines: 1-5	       
+
+its derivative with respect to the parameter
+
+.. math::
+
+   \frac{\partial F}{\partial\lambda} = -\mathrm e^u
+
+.. literalinclude:: ex23.py
+    :start-at: def df_dlmbda
+    :lines: 1-8	       
+
+and the Jacobian
+
+.. math::
+
+   J (u) = \frac{\mathrm d^2}{\mathrm dx^2} - \lambda \mathrm e^u
+
+.. literalinclude:: ex23.py
+    :start-at: def jacobian_solver
+    :lines: 1-11	       
+
+The resulting bifurcation diagram, matches figure 1.1 (left) of Farrell, Birkisson, & Funke (2015).
+
+.. figure:: ex23.png
+
 
 * P. E. Farrell, Á. Birkisson, & S. W. Funke (2015). Deflation techniques for finding distinct solutions of nonlinear partial differential equations. SIAM Journal on Scientific Computing 37(4). pp. A2026-A2045. `doi:10.1137/140984798 <http://dx.doi.org/10.1137/140984798>`_
   


### PR DESCRIPTION
I started out correcting a mistaken type-hint

https://github.com/kinnala/scikit-fem/blob/c8ad891eb94532aa51bd634b6bd9a05622f81400/docs/examples/ex23.py#L51

and took the opportunity to document how this example works.  (This while working towards using a similar technique to extend the backward-facing step in ex24 to nonzero Reynolds number, having decided against `scipy.optimize.root` #119.)
