### PR TITLE
savefig with splitext(argv[0])[0]

### DIFF
--- a/docs/examples/ex01.py
+++ b/docs/examples/ex01.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 from skfem import *
 
 m = MeshTri()
@@ -24,5 +23,8 @@ x = 0*b
 x[I] = solve(*condense(A, b, I=I))
 
 if __name__ == "__main__":
+    from os.path import splitext
+    from sys import argv
+    
     m.plot(x, smooth=True, colorbar=True)
-    m.savefig(Path(__file__).stem + '_solution.png')
+    m.savefig(splitext(argv[0])[0] + '_solution.png')

--- a/docs/examples/ex02.py
+++ b/docs/examples/ex02.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 from skfem import *
 import numpy as np
 
@@ -59,7 +58,10 @@ x = np.zeros_like(f)
 x[I] = solve(*condense(K, f, I=I))
 
 if __name__ == "__main__":
+    from os.path import splitext
+    from sys import argv
+    
     M, X = ib.refinterp(x, 3)
     ax = m.draw()
     M.plot(X, smooth=True, ax=ax, colorbar=True)
-    M.savefig(Path(__file__).stem + '_solution.png')
+    M.savefig(splitext(argv[0])[0] + '_solution.png')

--- a/docs/examples/ex05.py
+++ b/docs/examples/ex05.py
@@ -47,5 +47,8 @@ I = np.append(I, K.shape[0]-1)
 x[I] = solve(*condense(K, f, I=I))
 
 if __name__ == "__main__":
+    from os.path import splitext
+    from sys import argv
+    
     m.plot(x[:-1], colorbar=True)
-    m.savefig(Path(__file__).stem + '_solution.png')
+    m.savefig(splitext(argv[0])[0] + '_solution.png')

--- a/docs/examples/ex06.py
+++ b/docs/examples/ex06.py
@@ -24,6 +24,9 @@ x[I] = solve(*condense(K, f, D=D))
 M, X = ib.refinterp(x, 3)
 
 if __name__ == "__main__":
+    from os.path import splitext
+    from sys import argv
+    
     ax = m.draw()
     M.plot(X, smooth=True, edgecolors='', ax=ax)
-    M.savefig(Path(__file__).stem + '_solution.png')
+    M.savefig(splitext(argv[0])[0] + '_solution.png')

--- a/docs/examples/ex09.py
+++ b/docs/examples/ex09.py
@@ -28,4 +28,7 @@ Aint, bint = condense(A, b, I=I)
 x[I] = solve(Aint, bint, solver=solver_iter_pcg(pc=build_pc_ilu(Aint), verbose=verbose))
 
 if verbose:
-    m.save("ex09.vtk", x)
+    from os.path import splitext
+    from sys import argv
+
+    m.save(splitext(argv[0])[0] + ".vtk", x)

--- a/docs/examples/ex11.py
+++ b/docs/examples/ex11.py
@@ -29,4 +29,7 @@ for itr in range(3):
     m.p[itr, :] += sf*u[ib.nodal_dofs[itr, :]]
 
 if __name__ == "__main__":
-    m.save('elasticity.vtk')
+    from os.path import splitext
+    from sys import argv
+    
+    m.save(splitext(argv[0])[0] + '.vtk')

--- a/docs/examples/ex20.py
+++ b/docs/examples/ex20.py
@@ -48,9 +48,6 @@ psi = np.zeros_like(rotf)
 psi[ib.complement_dofs(D)] = solve(*condense(stokes, rotf, D=D))
 
 
-from os.path import splitext
-from sys import argv
-
 from matplotlib.tri import Triangulation
 
 # Evaluate the stream-function at the origin.
@@ -59,11 +56,15 @@ print('psi0 = {} (cf. exact = 1/64 = {})'.format(psi0, 1/64))
     
 if __name__ == "__main__":
     
+    from os.path import splitext
+    from sys import argv
+
     M, Psi = ib.refinterp(psi, 3)
 
     ax = mesh.draw()
     ax.tricontour(Triangulation(M.p[0, :], M.p[1, :], M.t.T), Psi)
-    ax.get_figure().savefig(splitext(argv[0])[0] + '_stream-lines.png')
+    name = splitext(argv[0])[0]
+    ax.get_figure().savefig(f'{name}_stream-lines.png')
 
     refbasis = InteriorBasis(M, ElementTriP1())
     velocity = np.vstack([derivative(Psi, refbasis, refbasis, 1),
@@ -74,4 +75,4 @@ if __name__ == "__main__":
     x = M.p[:, ::sparsity_factor]
     u = vector_factor * velocity[:, ::sparsity_factor]
     ax.quiver(x[0], x[1], u[0], u[1], x[0])
-    ax.get_figure().savefig(splitext(argv[0])[0] + '_velocity-vectors.png')
+    ax.get_figure().savefig(f'{name}_velocity-vectors.png')


### PR DESCRIPTION
…so that it ends up in docs/examples, beside the script (`argv[0]`), where the .rst expects it, regardless of where it's called from.

fixes #143