### PR TITLE
new example: plane Graetz

### DIFF
--- a/docs/examples/plane_graetz.py
+++ b/docs/examples/plane_graetz.py
@@ -1,0 +1,44 @@
+from skfem import *
+from skfem.models.poisson import laplace
+
+from math import ceil
+
+import numpy as np
+
+mesh_inlet_n = 2**5
+height = 1.
+length = 10.
+peclet = 1e2
+
+basis = InteriorBasis(
+    (MeshLine(np.linspace(0, length,
+                          ceil(mesh_inlet_n / height * length)))
+     * MeshLine(np.linspace(0, height / 2, mesh_inlet_n)))._splitquads(),
+    ElementTriP2())
+
+
+@bilinear_form
+def advection(u, du, v, dv, w):
+    _, y = w.x
+    velocity_0 = 6 * y * (height - y)  # parabolic plane Poiseuille
+    return v * velocity_0 * du[0]
+
+
+dofs = {'inlet': basis.get_dofs(lambda x, y: x == 0.),
+        'floor': basis.get_dofs(lambda x, y: y == 0.)}
+D = np.concatenate([d.nodal['u'] for d in dofs.values()])
+interior = basis.complement_dofs(D)
+
+A = asm(laplace, basis) + peclet * asm(advection, basis)
+t = np.zeros(basis.N)
+t[dofs['floor'].nodal['u']] = 1.
+t[interior] = solve(*condense(A, np.zeros_like(t), t, D=D))
+
+
+if __name__ == '__main__':
+
+    from pathlib import Path
+
+    basis.mesh.plot(t[basis.nodal_dofs.flatten()], edgecolors='none')
+    basis.mesh.savefig(Path(__file__).with_suffix('.png'),
+                       bbox_inches='tight', pad_inches=0)

--- a/docs/examples/plane_graetz.py
+++ b/docs/examples/plane_graetz.py
@@ -10,11 +10,10 @@ height = 1.
 length = 10.
 peclet = 1e2
 
-basis = InteriorBasis(
-    (MeshLine(np.linspace(0, length,
-                          ceil(mesh_inlet_n / height * length)))
-     * MeshLine(np.linspace(0, height / 2, mesh_inlet_n)))._splitquads(),
-    ElementTriP2())
+mesh = (MeshLine(np.linspace(0, length,
+                             ceil(mesh_inlet_n / height * length)))
+        * MeshLine(np.linspace(0, height / 2, mesh_inlet_n)))._splitquads()
+basis = InteriorBasis(mesh, ElementTriP2())
 
 
 @bilinear_form
@@ -39,6 +38,6 @@ if __name__ == '__main__':
 
     from pathlib import Path
 
-    basis.mesh.plot(t[basis.nodal_dofs.flatten()], edgecolors='none')
-    basis.mesh.savefig(Path(__file__).with_suffix('.png'),
-                       bbox_inches='tight', pad_inches=0)
+    mesh.plot(t[basis.nodal_dofs.flatten()], edgecolors='none')
+    mesh.savefig(Path(__file__).with_suffix('.png'),
+                 bbox_inches='tight', pad_inches=0)

--- a/docs/examples/plane_graetz.py
+++ b/docs/examples/plane_graetz.py
@@ -26,12 +26,12 @@ def advection(u, du, v, dv, w):
 
 dofs = {'inlet': basis.get_dofs(lambda x, y: x == 0.),
         'floor': basis.get_dofs(lambda x, y: y == 0.)}
-D = np.concatenate([d.nodal['u'] for d in dofs.values()])
+D = np.concatenate([d.all() for d in dofs.values()])
 interior = basis.complement_dofs(D)
 
 A = asm(laplace, basis) + peclet * asm(advection, basis)
 t = np.zeros(basis.N)
-t[dofs['floor'].nodal['u']] = 1.
+t[dofs['floor'].all()] = 1.
 t[interior] = solve(*condense(A, np.zeros_like(t), t, D=D))
 
 

--- a/docs/examples/plane_graetz.rst
+++ b/docs/examples/plane_graetz.rst
@@ -1,0 +1,18 @@
+Forced convection
+-----------------
+
+We begin the study of forced convection with the plane Graetz problem; viz. the steady distribution of temperature in a plane channel with unit inlet temperature and zero temperature on the walls and a steady laminar unidirectional parabolic plane-Poiseuille flow.
+
+The governing advection–diffusion equation is
+
+.. math::
+
+   \mathrm{Pe} u\cdot\frac{\partial T}{\partial x} = \nabla^2 T
+
+where the velocity profile is
+
+.. math::
+
+   u (y) = 6 y (1 - y), \qquad (0 < y < 1)
+
+The equations here have been nondimensionalized by the width of the channel and the volumetric flow-rate.  The governing parameter is the Péclet number, being the mean velocity times the width divided by the thermal diffusivity.

--- a/docs/examples/plane_graetz.rst
+++ b/docs/examples/plane_graetz.rst
@@ -16,3 +16,5 @@ where the velocity profile is
    u (y) = 6 y (1 - y), \qquad (0 < y < 1)
 
 The equations here have been nondimensionalized by the width of the channel and the volumetric flow-rate.  The governing parameter is the Péclet number, being the mean velocity times the width divided by the thermal diffusivity.
+
+Because the problem is symmetric about :math:`y = \frac{1}{2}`, only half is solved here, with natural boundary conditions along the centreline.


### PR DESCRIPTION
After the steady Navier–Stokes example #145 is sorted out, I was planning on extending it to include forced convective heat transfer, as in Blackwell & Pepper's 1992 [_Benchmark Problems for Heat Transfer Codes_](https://www.worldcat.org/title/benchmark-problems-for-heat-transfer-codes-presented-at-the-winter-annual-meeting-of-the-american-society-of-mechanical-engineers-anaheim-california-november-8-13-1992/oclc/28344562)); however, before that, it probably makes sense to try advection–diffusion with a known velocity field, e.g. the Graetz problem, which is done here.