### PR TITLE
correct implementation of damped Newton iteration

### DIFF
--- a/docs/examples/ex10.py
+++ b/docs/examples/ex10.py
@@ -26,17 +26,17 @@ I = m.interior_nodes()
 D = m.boundary_nodes()
 x[D] = np.sin(np.pi*m.p[0, D]) 
 
-relaxation = 0.7
 for itr in range(100):
+    import copy
     w = basis.interpolate(x)
     J = asm(jacobian, basis, w=w)
     F = asm(rhs, basis, w=w)
-    decrement = solve(*condense(J, F, I=I))
-    x[I] -= relaxation * decrement
-    if np.linalg.norm(decrement) < 1e-8:
+    xprev = copy.deepcopy(x)
+    x[I] = 0.3*x[I] + 0.7*solve(*condense(J, -F, I=I))
+    if np.linalg.norm(x - xprev) < 1e-8:
         break
     if __name__ == "__main__":
-        print(np.linalg.norm(decrement))
+        print(np.linalg.norm(x - xprev))
 
 if __name__ == "__main__":
     m.plot3(x)

--- a/docs/examples/ex10.py
+++ b/docs/examples/ex10.py
@@ -26,17 +26,17 @@ I = m.interior_nodes()
 D = m.boundary_nodes()
 x[D] = np.sin(np.pi*m.p[0, D]) 
 
+relaxation = 0.7
 for itr in range(100):
-    import copy
     w = basis.interpolate(x)
     J = asm(jacobian, basis, w=w)
     F = asm(rhs, basis, w=w)
-    xprev = copy.deepcopy(x)
-    x[I] = 0.3*x[I] + 0.7*solve(*condense(J, -F, I=I))
-    if np.linalg.norm(x - xprev) < 1e-8:
+    decrement = solve(*condense(J, F, I=I))
+    x[I] -= relaxation * decrement
+    if np.linalg.norm(decrement) < 1e-8:
         break
     if __name__ == "__main__":
-        print(np.linalg.norm(x - xprev))
+        print(np.linalg.norm(decrement))
 
 if __name__ == "__main__":
     m.plot3(x)

--- a/docs/examples/ex10.py
+++ b/docs/examples/ex10.py
@@ -32,7 +32,7 @@ for itr in range(100):
     J = asm(jacobian, basis, w=w)
     F = asm(rhs, basis, w=w)
     xprev = copy.deepcopy(x)
-    x[I] = 0.3*x[I] + 0.7*solve(*condense(J, -F, I=I))
+    x[I] = x[I] + 0.7*solve(*condense(J, -F, I=I))
     if np.linalg.norm(x - xprev) < 1e-8:
         break
     if __name__ == "__main__":

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -64,7 +64,7 @@ class TestEx10(unittest.TestCase):
     """Run examples/ex10.py"""
     def runTest(self):
         import docs.examples.ex10 as ex10
-        self.assertAlmostEqual(np.mean(ex10.x), 0.14566021189334058)
+        self.assertAlmostEqual(np.mean(ex10.x), 0.277931521728906)
 
 class TestEx11(unittest.TestCase):
     """Run examples/ex11.py"""


### PR DESCRIPTION
While still lamenting the disappointing failure of `scipy.optimize.root` to handle sparse Jacobians in #119, I took another look at the hand-implementation of damped Newton iteration in ex10. I'm not sure it's correct?

https://github.com/kinnala/scikit-fem/blob/752dc7f47043f818c2c64c1d697c36881c7a3bd7/docs/examples/ex10.py#L35

I think it's more supposed to look like 
```python
x[I] -= 0.7 * solve(*condense(J, F, I=I))
```

as in equation 1.8b' of 

*  Seydel, R. (1988). _From Equilibrium to Chaos: Practical Bifurcation and Stability Analysis._ New York: Elsevier. ISBN: 0444012508

Compare the old and new figures, below; the new one looks more like what a soap-film would do.

![ex10-old](https://user-images.githubusercontent.com/1588947/55368564-2f375700-553e-11e9-8d07-49bf5ab50a68.png)

_**Figure:—**_ Old

![ex10-new](https://user-images.githubusercontent.com/1588947/55368565-2f375700-553e-11e9-9f5c-5399a4d22578.png)

_**Figure:—**_ New
