### PR TITLE
demonstrate use of new elements keyword to restrict asm to subdomain

### DIFF
--- a/docs/examples/ex26.py
+++ b/docs/examples/ex26.py
@@ -6,12 +6,13 @@ import numpy as np
 from ex17 import mesh, basis, radii, joule_heating, thermal_conductivity
 
 
-L = asm(laplace, basis)
-f = asm(unit_load, basis)
 
 insulation = np.unique(basis.element_dofs[:, mesh.subdomains['insulation']])
 temperature = np.zeros(basis.N)
 wire = basis.complement_dofs(insulation)
+wire_basis = InteriorBasis(mesh, basis.elem, elements=mesh.subdomains['wire'])
+L = asm(laplace, wire_basis)
+f = asm(unit_load, wire_basis)
 temperature[wire] = solve(*condense(thermal_conductivity['wire'] * L,
                                     joule_heating * f,
                                     D=insulation))


### PR DESCRIPTION
This accompanies the discussion of #166.

> But after starting to modify ex26 to conform to this, I became unsure whether this is something that is actually wanted there.

I believe that this modifies ex26 to make use of the new `elements` keyword argument (presumably thereby skipping wasted assembly on unused subdomains in `asm`) but not otherwise changing its behaviour.