### PR TITLE
enable MeshLine.load

### DIFF
--- a/skfem/mesh/mesh.py
+++ b/skfem/mesh/mesh.py
@@ -284,6 +284,7 @@ class Mesh():
 
         # element to boundary element type mapping
         bnd_type = {
+            'line': 'vertex',
             'triangle' : 'line',
             'quad' : 'line',
             'tetra' : 'triangle',

--- a/skfem/mesh/mesh_line.py
+++ b/skfem/mesh/mesh_line.py
@@ -100,19 +100,18 @@ class MeshLine(Mesh):
         p = self.p
 
         # new vertices and elements
-        midpoints = p[:, self.t].mean(axis=1)
-        newp = np.hstack((p, midpoints))
-        # update fields
-        self.p = newp
-        self.facets = np.hstack(
-            [self.facets,
-             self.facets.shape[1] + np.arange(self.t.shape[1])[None, :]])
+        newp = np.hstack((p, p[:, self.t].mean(axis=1)))
         newt = np.empty((self.t.shape[0], 2 * self.t.shape[1]),
                         dtype=self.t.dtype)
         newt[0, ::2] = self.t[0]
         newt[0, 1::2] = p.shape[1] + np.arange(self.t.shape[1])
         newt[1, ::2] = newt[0, 1::2]
         newt[1, 1::2] = self.t[1]
+        # update fields
+        self.p = newp
+        self.facets = np.hstack(
+            [self.facets,
+             self.facets.shape[1] + np.arange(self.t.shape[1])[None, :]])
         self.t = newt
         self._build_mappings()
 

--- a/skfem/mesh/mesh_line.py
+++ b/skfem/mesh/mesh_line.py
@@ -28,6 +28,11 @@ class MeshLine(Mesh):
         if len(p.shape) == 1:
             p = np.array([p]) 
         self.p = p
+        if t is None:
+            self.t = np.vstack([self.p[:-1],
+                                self.p[1:]])
+        else:
+            self.t = t
         self._build_mappings()
 
         if validate:
@@ -41,9 +46,8 @@ class MeshLine(Mesh):
 
     def _build_mappings(self):
         """Build t, t2f and f2t"""
-        self.t = np.array([np.arange(np.max(self.p.shape)-1), np.arange(np.max(self.p.shape)-1)+1])
 
-        self.facets = np.array([np.arange(self.p.shape[1])])
+        self.facets = np.hstack([self.t[0], self.t[1, -1:]])
         self.t2f = self.t
         # build f2t
         e_tmp = np.hstack((self.t2f[0, :], self.t2f[1, :]))

--- a/skfem/mesh/mesh_line.py
+++ b/skfem/mesh/mesh_line.py
@@ -40,8 +40,7 @@ class MeshLine(Mesh):
         return cls()
 
     def _build_mappings(self):
-        """Build t2f and f2t. Also sorts p and builds t."""
-        self.p = np.sort(self.p)
+        """Build t, t2f and f2t"""
         self.t = np.array([np.arange(np.max(self.p.shape)-1), np.arange(np.max(self.p.shape)-1)+1])
 
         self.facets = np.array([np.arange(self.p.shape[1])])

--- a/skfem/mesh/mesh_line.py
+++ b/skfem/mesh/mesh_line.py
@@ -101,7 +101,7 @@ class MeshLine(Mesh):
 
         mid = range(self.t.shape[1]) + np.max(self.t) + 1
         # new vertices and elements
-        newp = np.hstack((p, 0.5*(p[:, self.t[0, :]] + p[:, self.t[1, :]])))
+        newp = np.hstack((p, p[:, self.t].mean(axis=1)))
         # update fields
         self.p = newp
         self._build_mappings()

--- a/skfem/mesh/mesh_line.py
+++ b/skfem/mesh/mesh_line.py
@@ -146,3 +146,7 @@ class MeshLine(Mesh):
 
     def mapping(self):
         return MappingAffine(self)
+
+    @staticmethod
+    def strip_extra_coordinates(p: ndarray) -> ndarray:
+        return p[:, :1]

--- a/skfem/mesh/mesh_line.py
+++ b/skfem/mesh/mesh_line.py
@@ -28,11 +28,10 @@ class MeshLine(Mesh):
         if len(p.shape) == 1:
             p = np.array([p]) 
         self.p = p
-        if t is None:
-            self.t = np.vstack([self.p[:-1],
-                                self.p[1:]])
-        else:
-            self.t = t
+        
+        self.facets = np.arange(self.p.shape[1])[None, :]
+        self.t = np.vstack([self.facets[0, :-1],
+                            self.facets[0, 1:]]) if t is None else t
         self._build_mappings()
 
         if validate:
@@ -45,9 +44,8 @@ class MeshLine(Mesh):
         return cls()
 
     def _build_mappings(self):
-        """Build t, t2f and f2t"""
+        """Build t2f and f2t"""
 
-        self.facets = np.hstack([self.t[0], self.t[1, -1:]])
         self.t2f = self.t
         # build f2t
         e_tmp = np.hstack((self.t2f[0, :], self.t2f[1, :]))

--- a/skfem/mesh/mesh_line.py
+++ b/skfem/mesh/mesh_line.py
@@ -99,11 +99,21 @@ class MeshLine(Mesh):
         # rename variables
         p = self.p
 
-        mid = range(self.t.shape[1]) + np.max(self.t) + 1
         # new vertices and elements
-        newp = np.hstack((p, p[:, self.t].mean(axis=1)))
+        midpoints = p[:, self.t].mean(axis=1)
+        newp = np.hstack((p, midpoints))
         # update fields
         self.p = newp
+        self.facets = np.hstack(
+            [self.facets,
+             self.facets.shape[1] + np.arange(self.t.shape[1])[None, :]])
+        newt = np.empty((self.t.shape[0], 2 * self.t.shape[1]),
+                        dtype=self.t.dtype)
+        newt[0, ::2] = self.t[0]
+        newt[0, 1::2] = p.shape[1] + np.arange(self.t.shape[1])
+        newt[1, ::2] = newt[0, 1::2]
+        newt[1, 1::2] = self.t[1]
+        self.t = newt
         self._build_mappings()
 
     def boundary_nodes(self):


### PR DESCRIPTION
For #175, which in a minimal sense is just because `'line'` is missing from the `dict` in `bnd_types` in 'Mesh._parse_submeshes`, but I'll check whether anything else is required.