### PR TITLE
simplify skfem.utils.solver_iter_krylov by passing on kwargs

### DIFF
--- a/docs/examples/ex09.py
+++ b/docs/examples/ex09.py
@@ -21,10 +21,10 @@ if __name__ == "__main__":
 else:
     verbose = False
 # run conjugate gradient with the default preconditioner
-x[I] = solve(*condense(A, b, I=I), solver=solver_iter_pcg(verbose=verbose))
+Aint, bint = condense(A, b, I=I)
+x[I] = solve(Aint, bint, solver=solver_iter_pcg(verbose=verbose))
 
 # run conjugate gradient with the incomplete LU preconditioner
-Aint, bint = condense(A, b, I=I)
 x[I] = solve(Aint, bint,
              solver=solver_iter_pcg(M=build_pc_ilu(Aint), verbose=verbose))
 

--- a/docs/examples/ex09.py
+++ b/docs/examples/ex09.py
@@ -25,7 +25,8 @@ x[I] = solve(*condense(A, b, I=I), solver=solver_iter_pcg(verbose=verbose))
 
 # run conjugate gradient with the incomplete LU preconditioner
 Aint, bint = condense(A, b, I=I)
-x[I] = solve(Aint, bint, solver=solver_iter_pcg(pc=build_pc_ilu(Aint), verbose=verbose))
+x[I] = solve(Aint, bint,
+             solver=solver_iter_pcg(M=build_pc_ilu(Aint), verbose=verbose))
 
 if verbose:
     from os.path import splitext


### PR DESCRIPTION
Fixes #188 by enabling the user to pass on whatever they like to the underlying solver.