### PR TITLE
better tests of Boussinesq k-factors of disk ex12 

### DIFF
--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -105,9 +105,9 @@ class TestEx16(unittest.TestCase):
 class TestEx12(unittest.TestCase):
     def runTest(self):
         import docs.examples.ex12 as ex
-        self.assertTrue(abs(ex.area - np.pi) < 1e-2)
-        self.assertTrue(abs(ex.k - 1/8/np.pi) < 1e-5)
-        self.assertTrue(abs(ex.k1 - 1/4/np.pi) < 1e-5)
+        self.assertAlmostEqual(ex.area, np.pi, delta=1e-2)
+        self.assertAlmostEqual(ex.k, 1/8/np.pi, delta=1e-5)
+        self.assertAlmostEqual(ex.k1, 1/4/np.pi, delta=1e-5)
 
 
 class TestEx13(unittest.TestCase):

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -105,8 +105,9 @@ class TestEx16(unittest.TestCase):
 class TestEx12(unittest.TestCase):
     def runTest(self):
         import docs.examples.ex12 as ex
-        area = ex.area
-        self.assertTrue((area - np.pi)<1e-3)
+        self.assertTrue(abs(ex.area - np.pi) < 1e-2)
+        self.assertTrue(abs(ex.k - 1/8/np.pi) < 1e-5)
+        self.assertTrue(abs(ex.k1 - 1/4/np.pi) < 1e-5)
 
 
 class TestEx13(unittest.TestCase):


### PR DESCRIPTION
The test #115 that the computed area exceeded the exact value π by at least a thousandth was too lenient because the triangulation is smaller than the disk; the test is here strengthened with `abs`.

Also just testing the area only tests the mesh rather than the solution.  Two exact functionals of this are known in closed form, so they're tested here too.
