### PR TITLE
don't print or plot in a test

### DIFF
--- a/docs/examples/ex20.py
+++ b/docs/examples/ex20.py
@@ -54,12 +54,13 @@ from matplotlib.tri import Triangulation
 
 # Evaluate the stream-function at the origin.
 psi0, = ib.interpolator(psi)(np.zeros((2, 1)))
-print('psi0 = {} (cf. exact = 1/64 = {})'.format(psi0, 1/64))
     
 if __name__ == "__main__":
     
     from os.path import splitext
     from sys import argv
+
+    print('psi0 = {} (cf. exact = 1/64 = {})'.format(psi0, 1/64))
 
     M, Psi = ib.refinterp(psi, 3)
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -114,7 +114,7 @@ class TestEx13(unittest.TestCase):
         import docs.examples.ex13 as ex
         u = ex.u
         A = ex.A
-        self.assertTrue((u @ A @ u - 2 * np.log(2) / np.pi)<1e-3)
+        self.assertAlmostEqual(u @ A @ u, 2 * np.log(2) / np.pi, delta=1e-3)
 
 
 class TestEx20(unittest.TestCase):

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -121,7 +121,7 @@ class TestEx20(unittest.TestCase):
     def runTest(self):
         import docs.examples.ex20 as ex
         psi0 = ex.psi0
-        self.assertTrue((psi0 - 1/64)<1e-3)
+        self.assertAlmostEqual(psi0, 1/64, delta=1e-3)
 
 
 class TestEx21(unittest.TestCase):


### PR DESCRIPTION
I noticed that since ex13 was added to the test-suite #116, a plot was thrown up.

This proposal restricts printing and plotting to when the example is run rather than merely imported.
