### PR TITLE
prefer functional to linear form in postprocessing where applicable

### DIFF
--- a/docs/examples/ex13.py
+++ b/docs/examples/ex13.py
@@ -46,16 +46,15 @@ conductance = {'skfem': u @ A @ u,
                'exact': 2 * np.log(2) / np.pi}
 
 
-@linear_form
-def port_flux(v, dv, w):
-    return sum(w.n * dv)
+@functional
+def port_flux(w):
+    return sum(w.n * w.dw)
 
 
 current = {}
 for port, boundary in mesh.boundaries.items():
     basis = FacetBasis(mesh, elements, facets=boundary)
-    form = asm(port_flux, basis)
-    current[port] = form @ u
+    current[port] = asm(port_flux, basis, w=basis.interpolate(u))
 
 if __name__ == '__main__':
 

--- a/docs/examples/ex22.py
+++ b/docs/examples/ex22.py
@@ -24,7 +24,7 @@ def eval_estimator(m, u):
         x, y = w.x
         return h**2 * load_func(x, y)**2
 
-    eta_K = asm(interior_residual, basis, w=basis.interpolate(u))
+    eta_K = interior_residual.elemental(basis, w=basis.interpolate(u))
     
     # facet jump
     fbasis = [FacetBasis(m, e, side=i) for i in [0, 1]]   
@@ -38,7 +38,7 @@ def eval_estimator(m, u):
         return h * ((du1[0] - du2[0])*n[0] +\
                     (du1[1] - du2[1])*n[1])**2
 
-    eta_E = asm(edge_jump, fbasis[0], w=w)
+    eta_E = edge_jump.elemental(fbasis[0], w=w)
     
     tmp = np.zeros(m.facets.shape[1])
     np.add.at(tmp, fbasis[0].find, eta_E)

--- a/skfem/assembly/form/functional.py
+++ b/skfem/assembly/form/functional.py
@@ -12,17 +12,18 @@ class Functional(Form):
 
     def kernel(self,
                w: FormParameters,
-               dx: ndarray) -> None:
+               dx: ndarray) -> ndarray:
         return np.sum(self.form(w) * dx, axis=1)
 
-    def assemble(self,
-                 ubasis: GlobalBasis,
-                 vbasis: Optional[GlobalBasis] = None,
-                 w: Optional[Any] = (None, None, None),
-                 nthreads: Optional[int] = 1) -> ndarray:
-        assert vbasis is None
-        vbasis = ubasis
+    def elemental(self,
+                  vbasis: GlobalBasis,
+                  w: Optional[Any] = (None, None, None)) -> ndarray:
         return self.kernel(self.parameters(w, vbasis), vbasis.dx)
+
+    def assemble(self,
+                 vbasis: GlobalBasis,
+                 w: Optional[Any] = (None, None, None)) -> float:
+        return sum(self.elemental(vbasis, w))
 
 
 def functional(form: Callable) -> Functional:


### PR DESCRIPTION
This is written atop #201 (standardizing output shape of functionals w.r.t. other forms) and #203 (tidying ex13), so the first six commits are just from them.

As mentioned in #200, following a discussion of things that functionals evaluated to floats could be used for (area of a triangular mesh, integral of a solution), it was realized that functionals would be a more natural choice for computing an integrated flux through a boundary than a linear form (followed by the application of that form to the solution).  This is implemented here.

There might be similar cases in other examples too.