### PR TITLE
enable command-line interface to test-scripts

### DIFF
--- a/tests/test_assembly.py
+++ b/tests/test_assembly.py
@@ -128,3 +128,6 @@ class BasisInterpolatorMorley(BasisInterpolator):
 
         return solve(M, f)
         
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_convergence.py
+++ b/tests/test_convergence.py
@@ -211,3 +211,7 @@ class ConvergenceLineP1(ConvergenceQ1):
     def setUp(self):
         self.mesh = MeshLine()
         self.mesh.refine(3)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -140,3 +140,7 @@ class TestEx22(unittest.TestCase):
         u = ex.u
         K = ex.K
         self.assertAlmostEqual(u.T @ K @ u, 0.2131280267335294)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_manufactured.py
+++ b/tests/test_manufactured.py
@@ -101,3 +101,7 @@ class LineNeumann1D(unittest.TestCase):
         u = solve(L + 1e-6*M, b) 
 
         self.assertTrue(np.sum(np.abs(u - m.p[0, :] + 0.5)) < 1e-4)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -97,3 +97,7 @@ class SaveLoadCycle(unittest.TestCase):
 
 class SaveLoadCycleHex(SaveLoadCycle):
     cls = MeshHex
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -24,3 +24,7 @@ class InitializeScalarField(unittest.TestCase):
 
         self.assertTrue(normest < 0.011,
                         msg = "|x-y| = {}".format(normest))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
In investigating the warnings in `tests.test_mesh.SaveLoadCycle` #205, I couldn't figure out how to get inside the test with `python -m unittest` or `pytest`, their `pdb` options only triggering on exceptions rather than warnings. There might well be a way to do it via those utilities, but the [basic example](https://docs.python.org/3/library/unittest.html?highlight=assertgreater#basic-example) for the `unittest` module suggests 
```python
if __name__ == '__main__':
    unittest.main()
```
as
> a simple way to run the tests. `unittest.main()` provides a command-line interface to the test script.

This proposal appends that block to each `tests/test_*.py`, which enables debugging via:
```shell
python -m pdb tests/test_mesh.py
```