### PR TITLE
STY: PEP-448-splat arguments for plotting

### DIFF
--- a/docs/examples/ex03.py
+++ b/docs/examples/ex03.py
@@ -33,6 +33,5 @@ L, x = eigsh(K[I].T[I].T, k=6, M=M[I].T[I].T, which='SM')
 y[I] = x[:, 4]
 
 if __name__ == "__main__":
-    MeshQuad(np.array([m.p[0, :] + y[gb.nodal_dofs[0, :]],
-                       m.p[1, :] + y[gb.nodal_dofs[1, :]]]), m.t).draw()
+    MeshQuad(np.array(m.p + y[gb.nodal_dofs]), m.t).draw()
     m.show()

--- a/docs/examples/ex11.py
+++ b/docs/examples/ex11.py
@@ -25,8 +25,7 @@ I = ib.complement_dofs(dofs)
 u[I] = solve(*condense(K, 0*u, I=I, x=u))
 
 sf = 1.0
-for itr in range(3):
-    m.p[itr, :] += sf*u[ib.nodal_dofs[itr, :]]
+m.p += sf * u[ib.nodal_dofs]
 
 if __name__ == "__main__":
     from os.path import splitext

--- a/docs/examples/ex18.py
+++ b/docs/examples/ex18.py
@@ -76,12 +76,10 @@ if __name__ == '__main__':
 
     ax = mesh.draw()
     velocity1 = velocity[basis['u'].nodal_dofs]
-    ax.quiver(mesh.p[0, :], mesh.p[1, :],
-              velocity1[0, :], velocity1[1, :],
-              mesh.p[0, :])         # colour by buoyancy
+    ax.quiver(*mesh.p, *velocity1, mesh.p[0, :])  # colour by buoyancy
     ax.get_figure().savefig(f'{name}_velocity.png')
 
     ax = mesh.draw()
-    ax.tricontour(Triangulation(mesh.p[0, :], mesh.p[1, :], mesh.t.T),
+    ax.tricontour(Triangulation(*mesh.p, mesh.t.T),
                   psi[basis['psi'].nodal_dofs.flatten()])
     ax.get_figure().savefig(f'{name}_stream-function.png')

--- a/docs/examples/ex20.py
+++ b/docs/examples/ex20.py
@@ -65,7 +65,7 @@ if __name__ == "__main__":
     M, Psi = ib.refinterp(psi, 3)
 
     ax = mesh.draw()
-    ax.tricontour(Triangulation(M.p[0, :], M.p[1, :], M.t.T), Psi)
+    ax.tricontour(Triangulation(*M.p, M.t.T), Psi)
     name = splitext(argv[0])[0]
     ax.get_figure().savefig(f'{name}_stream-lines.png')
 
@@ -77,5 +77,5 @@ if __name__ == "__main__":
     vector_factor = 2**3        # lengthen the arrows
     x = M.p[:, ::sparsity_factor]
     u = vector_factor * velocity[:, ::sparsity_factor]
-    ax.quiver(x[0], x[1], u[0], u[1], x[0])
+    ax.quiver(*x, *u, x[0])
     ax.get_figure().savefig(f'{name}_velocity-vectors.png')

--- a/docs/examples/ex21.py
+++ b/docs/examples/ex21.py
@@ -38,7 +38,5 @@ y[I] = x[:, 0]
 
 if __name__ == "__main__":
     sf = 2.0
-    MeshTet(np.array([m.p[0, :] + sf*y[ib.nodal_dofs[0, :]],\
-                      m.p[1, :] + sf*y[ib.nodal_dofs[1, :]],
-                      m.p[2, :] + sf*y[ib.nodal_dofs[2, :]]]), m.t).draw()
+    MeshTet(np.array(m.p + sf*y[ib.nodal_dofs]), m.t).draw()
     m.show()

--- a/docs/examples/ex24.py
+++ b/docs/examples/ex24.py
@@ -120,7 +120,7 @@ if __name__ == '__main__':
 
     n_streamlines = 11
     plot = partial(ax.tricontour,
-                   Triangulation(mesh.p[0, :], mesh.p[1, :], mesh.t.T),
+                   Triangulation(*mesh.p, mesh.t.T),
                    psi[basis['psi'].nodal_dofs.flatten()],
                    linewidths=1.)
     for levels, color, style in [

--- a/docs/examples/ex27.py
+++ b/docs/examples/ex27.py
@@ -156,8 +156,7 @@ class BackwardFacingStep:
         return ax
 
     def triangulation(self):
-        return Triangulation(
-            self.mesh.p[0, :], self.mesh.p[1, :], self.mesh.t.T)
+        return Triangulation(*self.mesh.p, self.mesh.t.T)
 
     def streamlines(self, psi: np.ndarray, n: int = 11, ax=None):
         if ax is None:


### PR DESCRIPTION
I just discovered [PEP-448 ‘Additional unpacking generalizations’](https://www.python.org/dev/peps/pep-0448/) which lets one concisely replace things like
```python
ax.quiver(mesh.p[0, :], mesh.p[1, :],
              velocity1[0, :], velocity1[1, :],
              mesh.p[0, :])         # colour by buoyancy
```
with
```python
ax.quiver(*mesh.p, *velocity1, mesh.p[0, :])  # colour by buoyancy
```

I also applied some simple vectorizations in a similar same spirit while I was looking through the examples for this; e.g. ex03.py.