### PR TITLE
Dirichlet doflocs

### DIFF
--- a/docs/examples/ex13.py
+++ b/docs/examples/ex13.py
@@ -39,7 +39,7 @@ u[boundary_dofs['positive'].all()] = 1.
 u[interior_dofs] = solve(*condense(A, 0.*u, u, interior_dofs))
 
 M = asm(mass, basis)
-u_exact = L2_projection(lambda x, y: 2 * np.arctan2(y, x) / np.pi, basis)
+u_exact = 2 * np.arctan2(*basis.doflocs[::-1]) / np.pi
 u_error = u - u_exact
 error_L2 = np.sqrt(u_error @ M @ u_error)
 conductance = {'skfem': u @ A @ u,

--- a/docs/examples/ex14.rst
+++ b/docs/examples/ex14.rst
@@ -3,7 +3,7 @@ Laplace with inhomogeneous boundary
 
 Another simple modification of :ref:`poisson`, this time showing how
 to impose coordinate-dependent Dirichlet conditions with
-:func:`~skfem.utils.condense` and :func:`~skfem.utils.L2_projection`.
+:func:`~skfem.utils.condense` and :func:`~skfem.InteriorBasis.doflocs`.
 The forcing term is suppressed for simplicity. The boundary values are
 set as the real part :math:`x^2 - y^2` of an analytic complex function
 :math:`(x + \mathrm i y)^2` which is harmonic and so that is the exact

--- a/docs/examples/ex27.py
+++ b/docs/examples/ex27.py
@@ -113,7 +113,6 @@ class BackwardFacingStep:
         return from_meshio(generate_mesh(geom, dim=2))
 
     def inlet_dofs(self):
-        inlet_dofs_ = self.basis['u'].get_dofs(self.mesh.boundaries['inlet'])
         inlet_dofs_ = self.basis['inlet'].get_dofs(
             self.mesh.boundaries['inlet'])
         return np.concatenate([inlet_dofs_.nodal[f'u^{1}'],


### PR DESCRIPTION
Following introduction of `InteriorBasis.doflocs` #223, use it in ex13 too.  

Also a couple of minor related iterms.