### PR TITLE
assume expansion in untested examples

### DIFF
--- a/docs/examples/ex18.py
+++ b/docs/examples/ex18.py
@@ -32,8 +32,7 @@ f = np.concatenate([asm(body_force, basis['u']),
                     np.zeros(B.shape[0])])
 
 D = basis['u'].get_dofs().all()
-uvp = np.zeros(K.shape[0])
-uvp[np.setdiff1d(np.arange(K.shape[0]), D)] = solve(*condense(K, f, D=D))
+uvp = solve(*condense(K, f, D=D))
 
 velocity, pressure = np.split(uvp, [A.shape[0]])
 

--- a/docs/examples/ex27.py
+++ b/docs/examples/ex27.py
@@ -211,14 +211,13 @@ class BackwardFacingStep:
                         uvp: np.ndarray,
                         reynolds: float,
                         rhs: np.ndarray) -> np.ndarray:
-        duvp = self.make_vector() - uvp
         u = self.basis['u'].interpolate(self.split(uvp)[0])
-        duvp[self.I] = solve(*condense(
+        duvp = solve(*condense(
             self.S +
             reynolds
             * block_diag([asm(acceleration_jacobian, self.basis['u'], w=u),
                           csr_matrix((self.basis['p'].N,)*2)]),
-            rhs, duvp, I=self.I))
+            rhs, self.make_vector() - uvp, I=self.I))
         return duvp
 
 


### PR DESCRIPTION
After #228, the left-hand side of a `solve(*condense(…))` should be the whole vector rather than just the degrees of freedom not constained by Dirichlet conditions.  A couple of untested examples slipped through.