### PR TITLE
use linear form rot from models.general in ex18

### DIFF
--- a/docs/examples/ex18.py
+++ b/docs/examples/ex18.py
@@ -36,10 +36,6 @@ uvp = solve(*condense(K, f, D=D))
 
 velocity, pressure = np.split(uvp, [A.shape[0]])
 
-@linear_form
-def rot(v, dv, w):
-    return dv[1] * w.w[0] - dv[0] * w.w[1]
-
 basis['psi'] = InteriorBasis(mesh, ElementTriP2())
 A = asm(laplace, basis['psi'])
 psi = np.zeros(A.shape[0])


### PR DESCRIPTION
`ex18` defines a `LinearForm rot`, presumably having done so before the same thing was added to `models.general`.  Redefinition can be confusing (is something different intended?) so it might be better to just use the one from the library (which I notice is imported anyway).