### PR TITLE
WIP: 1-norm isoparametric invF termination

### DIFF
--- a/skfem/mapping/mapping_isoparametric.py
+++ b/skfem/mapping/mapping_isoparametric.py
@@ -137,7 +137,7 @@ class MappingIsoparametric(Mapping):
             invDF = self.invDF(X, tind)
             dX = np.einsum('ijkl,jkl->ikl', invDF, x - F)
             X = X + dX
-            if np.sum(dX) < 1e-6:
+            if (np.linalg.norm(dX, 1, (0, 2)) < 1e-6).all():
                  break
         if (np.abs(X) > 1.0).any():
             raise ValueError("Inverse mapped point outside reference element!")


### PR DESCRIPTION
This is to demonstrate a point in the discussion of the use of an algebraic sum in the termination criterion for the Newton iteration in `MappingIsoparametric.invF` #249.  A 1-norm seems more appropriate but fails five tests:
* 3 in `test_assembly`
* 1 in `test_convergence`
* 1 in `test_mapping`