### PR TITLE
tolerance for exteriority test in invF

### DIFF
--- a/skfem/mapping/mapping_isoparametric.py
+++ b/skfem/mapping/mapping_isoparametric.py
@@ -137,7 +137,7 @@ class MappingIsoparametric(Mapping):
             invDF = self.invDF(X, tind)
             dX = np.einsum('ijkl,jkl->ikl', invDF, x - F)
             X = X + dX
-            if np.sum(dX) < 1e-6:
+            if (np.linalg.norm(dX, 1, (0, 2)) < 1e-6).all():
                  break
         if (np.abs(X) > 1.0).any():
             raise ValueError("Inverse mapped point outside reference element!")

--- a/skfem/mapping/mapping_isoparametric.py
+++ b/skfem/mapping/mapping_isoparametric.py
@@ -139,7 +139,7 @@ class MappingIsoparametric(Mapping):
             X = X + dX
             if (np.linalg.norm(dX, 1, (0, 2)) < 1e-6).all():
                  break
-        if (np.abs(X) > 1.0).any():
+        if (np.abs(X) > 1.0 + 1e-12).any():
             raise ValueError("Inverse mapped point outside reference element!")
         return X
 


### PR DESCRIPTION
Fixes #251 

Built atop #250 and so also fixes #249 (which #250 alone does not).

This also fixes #244, the original problem of broken Neumann problems relying on `FacetBasis` in `MeshQuad`.