### PR TITLE
DOC: improved animation of heat equation

### DIFF
--- a/docs/examples/Makefile
+++ b/docs/examples/Makefile
@@ -3,6 +3,7 @@ all: ex01_solution.png \
      ex05_solution.png \
      ex06_solution.png \
      ex17_solution.png \
+     ex19.gif \
      ex20_stream-lines.png ex20_velocity-vectors.png \
      ex23.png \
      ex25.png \
@@ -14,6 +15,8 @@ all: ex01_solution.png \
 	python $<
 %_solution.png: %.py
 	python $<
+%.gif: %.py
+	python $< --gif
 ex20_velocity-vectors.png: ex20.py
 	python $<
 ex20_stream-lines.png: ex20_velocity-vectors.png
@@ -21,5 +24,5 @@ ex27-750.0-psi.png: ex27.py
 	python $<
 ex27-150.0-psi.png ex27-450.0-psi.png: ex27-750.0-psi.png
 clean:
-	${RM} *.png *.vtk *~
+	${RM} *.png *.vtk *.gif *~
 .PHONY: all clean

--- a/docs/examples/Makefile
+++ b/docs/examples/Makefile
@@ -23,6 +23,7 @@ ex20_stream-lines.png: ex20_velocity-vectors.png
 ex27-750.0-psi.png: ex27.py
 	python $<
 ex27-150.0-psi.png ex27-450.0-psi.png: ex27-750.0-psi.png
+ex28-inlet-outlet.png: ex28.png
 clean:
 	${RM} *.png *.vtk *.gif *~
 .PHONY: all clean

--- a/docs/examples/ex19.py
+++ b/docs/examples/ex19.py
@@ -14,10 +14,10 @@ halfwidth = np.array([2., 3.])
 ncells = 2**3
 diffusivity = 5.
 
-mesh = (MeshLine(np.linspace(-1, 1, 2 * ncells) * halfwidth[0]) *
-        MeshLine(np.linspace(-1, 1,
-                             2 * ncells * ceil(halfwidth[1] // halfwidth[0]))
-                 * halfwidth[1]))._splitquads()
+mesh = MeshTri.init_tensor(
+    np.linspace(-1, 1, 2 * ncells) * halfwidth[0],
+    np.linspace(-1, 1, 2 * ncells * ceil(halfwidth[1] //
+                                         halfwidth[0])) * halfwidth[1])
 
 element = ElementTriP1()
 basis = InteriorBasis(mesh, element)
@@ -50,7 +50,7 @@ def step(t: float,
     return t + dt, u_new
 
 
-def evolve(t: float = 0.
+def evolve(t: float,
            u: np.ndarray) -> Iterator[Tuple[float, np.ndarray]]:
 
     while np.linalg.norm(u, np.inf) > 2**-3:

--- a/docs/examples/ex19.py
+++ b/docs/examples/ex19.py
@@ -14,12 +14,12 @@ halfwidth = np.array([2., 3.])
 ncells = 2**3
 diffusivity = 5.
 
-mesh = MeshTri.init_tensor(
+mesh = MeshQuad.init_tensor(
     np.linspace(-1, 1, 2 * ncells) * halfwidth[0],
     np.linspace(-1, 1, 2 * ncells * ceil(halfwidth[1] //
                                          halfwidth[0])) * halfwidth[1])
 
-element = ElementTriP1()
+element = ElementQuad1()
 basis = InteriorBasis(mesh, element)
 
 L = diffusivity * asm(laplace, basis)

--- a/docs/examples/ex19.py
+++ b/docs/examples/ex19.py
@@ -1,4 +1,5 @@
 from math import ceil
+from typing import Iterator, Tuple
 
 import numpy as np
 from scipy.sparse import csr_matrix
@@ -24,7 +25,7 @@ basis = InteriorBasis(mesh, element)
 L = diffusivity * asm(laplace, basis)
 M = asm(mass, basis)
 
-dt = 1.0 * (min(halfwidth) / ncells)**2 / diffusivity
+dt = .01
 print(f'dt = {dt} µs')
 theta = 0.5                     # Crank–Nicolson
 A = M + theta * L * dt
@@ -32,11 +33,29 @@ B = M - (1 - theta) * L * dt
 
 boundary = basis.get_dofs().all()
 interior = basis.complement_dofs(boundary)
-u = (np.cos(np.pi * mesh.p[0, :] / 2 / halfwidth[0])
-     * np.cos(np.pi * mesh.p[1, :] / 2 / halfwidth[1]))
 
 backsolve = cholesky(condense(A, D=boundary, expand=False)
                      .T)  # cholesky prefers CSC
+
+u_init = (np.cos(np.pi * mesh.p[0, :] / 2 / halfwidth[0])
+          * np.cos(np.pi * mesh.p[1, :] / 2 / halfwidth[1]))
+
+
+def step(t: float,
+         u: np.ndarray) -> Tuple[float, np.ndarray]:
+    u_new = np.zeros_like(u)              # zero Dirichlet conditions
+    _, b1 = condense(csr_matrix(A.shape),  # ignore condensed matrix
+                     B @ u, u_new, D=boundary, expand=False)
+    u_new[interior] = backsolve(b1)
+    return t + dt, u_new
+
+
+def evolve(t: float = 0.
+           u: np.ndarray) -> Iterator[Tuple[float, np.ndarray]]:
+
+    while np.linalg.norm(u, np.inf) > 2**-3:
+        t, u = step(t, u)
+        yield t, u
 
 
 if __name__ == '__main__':
@@ -47,23 +66,20 @@ if __name__ == '__main__':
     from matplotlib.animation import FuncAnimation
     import matplotlib.pyplot as plt
 
-    parser = ArgumentParser(description='heat equation')
-    parser.add_argument('-o', '--output')
+    parser = ArgumentParser(description='heat equation in a rectangle')
+    parser.add_argument('-g', '--gif', action='store_true',
+                        help='write animated GIF', )
     args = parser.parse_args()
-    
-    ax = mesh.plot(u, smooth=True)
-    field = ax.get_children()[0]
+
+    ax = mesh.plot(u_init, smooth=True)  # smooth is vertex-based
+
+    text = ax.text(.5, .9, 't = 0.',
+                   bbox={'color': 'w'}, transform=ax.transAxes)
+
+    field = ax.get_children()[0]  # vertex-based temperature-colour
+
     fig = ax.get_figure()
     fig.colorbar(field)
-
-    def evolve():
-        t = 0.
-        while np.linalg.norm(u, np.inf) > 2**-4:
-            _, b1 = condense(csr_matrix(A.shape),  # ignore condensed matrix
-                             B @ u, D=boundary, expand=False)
-            u[interior] = backsolve(b1)
-            t += dt
-            yield t, u
 
     def update(event):
         t, u = event
@@ -71,16 +87,16 @@ if __name__ == '__main__':
         u0 = {'skfem': basis.interpolator(u)(np.zeros((2, 1)))[0],
               'exact': np.exp(-diffusivity * np.pi**2 * t / 4 *
                               sum(halfwidth**-2))}
-        print(','.join(map(' {:.4f}'.format,
-                           (t, u0['skfem'], u0['skfem'] - u0['exact']))))
-        
-        field.set_array(u)
-        return field,
+        print('{:4.2f}, {:5.3f}, {:+7.4f}'.format(
+            t, u0['skfem'], u0['skfem'] - u0['exact']))
 
-    animation = FuncAnimation(fig, update, evolve, blit=True, repeat=False)
-    if args.output:
-        animation.save(
-            args.output,
-            {'.gif': 'imagemagick'}.get(Path(args.output).suffix))
+        text.set_text(f'$t$ = {t:.2f}')
+        field.set_array(u)
+        return text, field
+
+    animation = FuncAnimation(fig, update, evolve(0., u_init),
+                              blit=False, repeat=False)
+    if args.gif:
+        animation.save(Path(__file__).with_suffix('.gif'), 'imagemagick')
     else:
-          plt.show()
+        plt.show()

--- a/docs/examples/ex19.py
+++ b/docs/examples/ex19.py
@@ -72,12 +72,8 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     ax = mesh.plot(u_init, smooth=True)  # smooth is vertex-based
-
-    text = ax.text(.5, .9, 't = 0.',
-                   bbox={'color': 'w'}, transform=ax.transAxes)
-
+    title = ax.set_title('t = 0.00')
     field = ax.get_children()[0]  # vertex-based temperature-colour
-
     fig = ax.get_figure()
     fig.colorbar(field)
 
@@ -90,12 +86,10 @@ if __name__ == '__main__':
         print('{:4.2f}, {:5.3f}, {:+7.4f}'.format(
             t, u0['skfem'], u0['skfem'] - u0['exact']))
 
-        text.set_text(f'$t$ = {t:.2f}')
+        title.set_text(f'$t$ = {t:.2f}')
         field.set_array(u)
-        return text, field
 
-    animation = FuncAnimation(fig, update, evolve(0., u_init),
-                              blit=False, repeat=False)
+    animation = FuncAnimation(fig, update, evolve(0., u_init), repeat=False)
     if args.gif:
         animation.save(Path(__file__).with_suffix('.gif'), 'imagemagick')
     else:

--- a/docs/examples/ex19.rst
+++ b/docs/examples/ex19.rst
@@ -46,6 +46,10 @@ in turn requires the CHOLMOD library from `SuiteSparse
 <http://faculty.cse.tamu.edu/davis/suitesparse.html>`_.  The latter may not be
 available for all systems.
 
+.. figure:: ex19.gif
+
+   The decaying temperature field
+
 The complete source code reads as follows:
 
 .. literalinclude:: ex19.py


### PR DESCRIPTION
While working on operator-splitting techniques for the unsteady Navier–Stokes equation #240, I found it would be helpful to have a better idiom for animating transient solutions.  This documents them for the simpler example of the heat equation, ex19.

I've also taken the opportunity to make a number of other improvements to the example:
* Optionally save an animated GIF and include this in the docs.
* This optional behaviour is governed by a command-line flag via [`argparse`](https://docs.python.org/3/library/argparse.html) from the Python Standard Library.
  * The default behaviour is as before to display the solution as it's being simulated.
  * No duplication of code between the two modes is needed.
  * This parameterization of an example might also be useful in other cases:
    * type and order of meshes & elements #241 #244 #248
    * fineness of mesh or time-step or tolerance, or degree of nonlinearity, or time to run an unsteady simulation, e.g. to make a test quicker but an example run live at the terminal richer
    * just about any other aspect of a finite element problem
* Animation is sped up using [`matplotlib.animation.FuncAnimation`](https://matplotlib.org/api/_as_gen/matplotlib.animation.FuncAnimation.html#matplotlib.animation.FuncAnimation). (I haven't actually measured this.)
* `MeshQuad` in place of `MeshTri`: more natural for the geometry and also gives another `ElementQuad1` example #248. 
* The mesh is generated with `MeshQuad.init_tensor` instead of using the product of two `MeshLine`s.
* The solution is generated in the script rather than only when `__name__ == '__main__'`, or at least a generator `evolve` is written.  This makes ex19 more like the other examples that can have the solutions imported into `tests.test_examples`. This example still can't be tested as it relies on `sksparse`, but it does demonstrate an idiom for making future unsteady examples testable.