### PR TITLE
type & check corrections for cell_data in Mesh.save

### DIFF
--- a/skfem/mesh/mesh.py
+++ b/skfem/mesh/mesh.py
@@ -288,7 +288,7 @@ class Mesh():
                                  "a dictionary of ndarrays.")
 
         if cell_data is not None:
-            if not isinstance(point_data, dict):
+            if not isinstance(cell_data, dict):
                 raise ValueError("cell_data should be "
                                  "a dictionary of ndarrays.")
 

--- a/skfem/mesh/mesh.py
+++ b/skfem/mesh/mesh.py
@@ -291,6 +291,7 @@ class Mesh():
             if not isinstance(cell_data, dict):
                 raise ValueError("cell_data should be "
                                  "a dictionary of ndarrays.")
+            cell_data = {self.meshio_type: cell_data}
 
         cells = {self.meshio_type: self.t.T}
         mesh = meshio.Mesh(self.p.T, cells, point_data, cell_data)


### PR DESCRIPTION
Fixes #258 .

This does change the behaviour if `cell_data` is passed, to match the docs.  It's an alternative to #259 which preserved behaviour but changed the docs.