### PR TITLE
a few more uses of new skfem.visuals functionalities in examples

### DIFF
--- a/docs/examples/ex12.py
+++ b/docs/examples/ex12.py
@@ -35,5 +35,5 @@ if __name__ == '__main__':
     print('k = {:.5f} (exact = 1/8/pi = {:.5f})'.format(k, 1/np.pi/8))
     print("k' = {:.5f} (exact = 1/4/pi = {:.5f})".format(k1, 1/np.pi/4))
 
-    plot3(m, x[basis.nodal_dofs.flatten()])
+    plot3(basis, x)
     show()

--- a/docs/examples/ex14.py
+++ b/docs/examples/ex14.py
@@ -28,5 +28,5 @@ u = solve(*condense(A, np.zeros_like(u), u, I))
 if __name__ == "__main__":
     from skfem.visuals.matplotlib import plot, show
     print('||grad u||**2 = {:f} (exact = 8/3 = {:f})'.format(u @ A @ u, 8/3))
-    plot(m, u[basis.nodal_dofs.flatten()])
+    plot(basis, u)
     show()

--- a/docs/examples/ex17.py
+++ b/docs/examples/ex17.py
@@ -72,7 +72,7 @@ if __name__ == '__main__':
 
     from os.path import splitext
     from sys import argv
-    from skfem.visuals.matplotlib import draw, plot
+    from skfem.visuals.matplotlib import draw, plot, savefig
 
     T0 = {'skfem': basis.interpolator(temperature)(np.zeros((2, 1)))[0],
           'exact':
@@ -85,5 +85,5 @@ if __name__ == '__main__':
     print('Central temperature:', T0)
 
     ax = draw(mesh)
-    plot(mesh, temperature, ax=ax, edgecolors='none', colorbar=True)
-    ax.get_figure().savefig(splitext(argv[0])[0] + '_solution.png')
+    plot(basis, temperature, ax=ax, colorbar=True)
+    savefig(splitext(argv[0])[0] + '_solution.png')

--- a/docs/examples/ex18.py
+++ b/docs/examples/ex18.py
@@ -54,7 +54,7 @@ if __name__ == '__main__':
 
     from matplotlib.tri import Triangulation
 
-    from skfem.visuals.matplotlib import plot, draw
+    from skfem.visuals.matplotlib import plot, draw, savefig
 
     name = splitext(argv[0])[0]
 
@@ -68,15 +68,16 @@ if __name__ == '__main__':
                                                       [0.5, 0.5]])),
           '(cf. exact -/+ 1/8)')
 
-    ax = plot(mesh, pressure)
-    ax.get_figure().savefig(f'{name}_pressure.png')
+    ax = draw(mesh)
+    plot(basis['p'], pressure, ax=ax)
+    savefig(f'{name}_pressure.png')
 
     ax = draw(mesh)
     velocity1 = velocity[basis['u'].nodal_dofs]
     ax.quiver(*mesh.p, *velocity1, mesh.p[0, :])  # colour by buoyancy
-    ax.get_figure().savefig(f'{name}_velocity.png')
+    savefig(f'{name}_velocity.png')
 
     ax = draw(mesh)
     ax.tricontour(Triangulation(*mesh.p, mesh.t.T),
                   psi[basis['psi'].nodal_dofs.flatten()])
-    ax.get_figure().savefig(f'{name}_stream-function.png')
+    savefig(f'{name}_stream-function.png')

--- a/docs/examples/ex25.py
+++ b/docs/examples/ex25.py
@@ -41,6 +41,6 @@ if __name__ == '__main__':
     from pathlib import Path
     from skfem.visuals.matplotlib import plot, savefig
 
-    plot(mesh, t0, edgecolors='none')
+    plot(mesh, t0)
     savefig(Path(__file__).with_suffix('.png'),
             bbox_inches='tight', pad_inches=0)

--- a/docs/examples/ex28.py
+++ b/docs/examples/ex28.py
@@ -128,7 +128,7 @@ if __name__ == '__main__':
     from pathlib import Path
     from skfem.visuals.matplotlib import plot, savefig
 
-    plot(mesh, temperature, edgecolors='none')
+    plot(mesh, temperature)
     savefig(Path(__file__).with_suffix('.png'),
             bbox_inches='tight', pad_inches=0)
 

--- a/skfem/visuals/matplotlib.py
+++ b/skfem/visuals/matplotlib.py
@@ -252,6 +252,13 @@ def _(m: MeshTri, z: ndarray, **kwargs) -> Axes:
     return ax
 
 
+@plot3.register
+def _(basis: InteriorBasis, z: ndarray, **kwargs) -> Axes:
+    """Plot on a refined mesh via :meth:`InteriorBasis.refinterp`."""
+    Nrefs = kwargs["Nrefs"] if "Nrefs" in kwargs else 1
+    return plot3(*basis.refinterp(z, Nrefs=Nrefs), **kwargs)
+
+
 def savefig(*args, **kwargs):
     plt.savefig(*args, **kwargs)
 


### PR DESCRIPTION
Being able to plot(3) against a basis rather than a mesh means that if one has quadratic elements like
```python
basis = InteriorBasis(m, ElementTriP2())
```
then
```python
    plot3(m, x[basis.nodal_dofs.flatten()])
```
can be replaced with
```pytho
    plot3(basis, x)
```