### PR TITLE
import io rather than importers

### DIFF
--- a/docs/examples/ex12.py
+++ b/docs/examples/ex12.py
@@ -1,6 +1,6 @@
 from skfem import *
 from skfem.models.poisson import laplace, unit_load
-from skfem.importers import from_meshio
+from skfem.io import from_meshio
 
 import numpy as np
 

--- a/docs/examples/ex13.py
+++ b/docs/examples/ex13.py
@@ -1,6 +1,6 @@
 from skfem import *
 from skfem.models.poisson import laplace, mass
-from skfem.importers import from_meshio
+from skfem.io import from_meshio
 
 import numpy as np
 

--- a/docs/examples/ex17.py
+++ b/docs/examples/ex17.py
@@ -7,7 +7,7 @@ from pygmsh.built_in import Geometry
 
 from skfem import *
 from skfem.models.poisson import mass
-from skfem.importers.meshio import from_meshio
+from skfem.io import from_meshio
 
 radii = [2., 3.]
 joule_heating = 5.

--- a/docs/examples/ex20.py
+++ b/docs/examples/ex20.py
@@ -1,5 +1,5 @@
 from skfem import *
-from skfem.importers.meshio import from_meshio
+from skfem.io import from_meshio
 
 import numpy as np
 

--- a/docs/examples/ex24.py
+++ b/docs/examples/ex24.py
@@ -10,7 +10,7 @@ from pygmsh.built_in import Geometry
 from skfem import *
 from skfem.models.poisson import vector_laplace, mass, laplace
 from skfem.models.general import divergence, rot
-from skfem.importers.meshio import from_meshio
+from skfem.io import from_meshio
 
 
 def make_geom(length: float = 35.,

--- a/docs/examples/ex27.py
+++ b/docs/examples/ex27.py
@@ -1,7 +1,7 @@
 from skfem import *
 from skfem.models.poisson import vector_laplace, laplace
 from skfem.models.general import divergence, rot
-from skfem.importers.meshio import from_meshio
+from skfem.io import from_meshio
 
 from functools import partial
 from itertools import cycle, islice

--- a/docs/examples/ex28.py
+++ b/docs/examples/ex28.py
@@ -1,5 +1,5 @@
 from skfem import *
-from skfem.importers import from_meshio
+from skfem.io import from_meshio
 from skfem.models.poisson import unit_load
 
 from matplotlib.pyplot import subplots

--- a/skfem/mesh/mesh.py
+++ b/skfem/mesh/mesh.py
@@ -286,7 +286,7 @@ class Mesh():
             The filename of the mesh.
 
         """
-        from skfem.importers.meshio import from_file
+        from skfem.io.meshio import from_file
         return from_file(filename)
 
     def boundary_nodes(self) -> ndarray:


### PR DESCRIPTION
This avoids the `DeprecationWarning` from `tests` following the renaming of `skfem.importers` fb914104dae70557c9d7a66c372427a13be2ce35.
