### PR TITLE
Fix the order of Lame parameters

### DIFF
--- a/docs/examples/ex04.py
+++ b/docs/examples/ex04.py
@@ -82,19 +82,19 @@ for i in range(2):
 
         @BilinearForm
         def bilin_mortar(u, v, w):
-            ju = (-1.) ** i * dot(u, w.n)
-            jv = (-1.) ** j * dot(v, w.n)
+            ju = (-1.) ** j * dot(u, w.n)
+            jv = (-1.) ** i * dot(v, w.n)
             nxn = prod(w.n, w.n)
             mu = .5 * ddot(nxn, C(sym_grad(u)))
             mv = .5 * ddot(nxn, C(sym_grad(v)))
             return ((1. / (alpha * w.h) * ju * jv - mu * jv - mv * ju)
                     * (np.abs(w.x[1]) <= limit))
 
-        K[j][i] += asm(bilin_mortar, mb[i], mb[j])
+        K[i][j] += asm(bilin_mortar, mb[j], mb[i])
 
     @LinearForm
     def lin_mortar(v, w):
-        jv = (-1.) ** j * dot(v, w.n)
+        jv = (-1.) ** i * dot(v, w.n)
         mv = .5 * ddot(prod(w.n, w.n), C(sym_grad(v)))
         return ((1. / (alpha * w.h) * gap(w.x) * jv - gap(w.x) * mv)
                 * (np.abs(w.x[1]) <= limit))

--- a/skfem/models/elasticity.py
+++ b/skfem/models/elasticity.py
@@ -18,13 +18,13 @@ def lame_parameters(E, nu):
     Returns
     -------
     float
-        The first Lamé parameter
+        The first Lamé parameter (lambda)
     float
-        The second Lamé parameter
+        The second Lamé parameter (mu)
 
     """
-    return (E / (2. * (1. + nu)),
-            E * nu / ((1. + nu) * (1. - 2. * nu)))
+    return (E * nu / ((1. + nu) * (1. - 2. * nu)),
+            E / (2. * (1. + nu)))
 
 
 def linear_stress(Lambda=1., Mu=1.):

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -24,8 +24,8 @@ class TestEx03(unittest.TestCase):
 class TestEx04(unittest.TestCase):
     def runTest(self):
         import docs.examples.ex04 as ex04
-        self.assertAlmostEqual(np.max(ex04.vonmises1), 83.38149728489452)
-        self.assertAlmostEqual(np.max(ex04.vonmises2), 87.54678669104182)
+        self.assertAlmostEqual(np.max(ex04.vonmises1), 64.57919892367978)
+        self.assertAlmostEqual(np.max(ex04.vonmises2), 67.91419753783893)
 
 
 class TestEx05(unittest.TestCase):
@@ -143,7 +143,7 @@ class TestEx21(unittest.TestCase):
         y = ex.y
         K = ex.K
         L = ex.L[0]
-        self.assertAlmostEqual(L, 55869.71713984441, 4)
+        self.assertAlmostEqual(L, 40085.40062937357, 4)
         self.assertAlmostEqual(L, y.T @ K @ y, 4)
 
 


### PR DESCRIPTION
I ran into an issue with the convergence of ex04 and then realized that the Lamè parameters in `skfem.models.elasticity.lame_parameters` were defined wrong way around (when passed on directly to `skfem.models.elasticity.linear_elasticity`. Do you agree @gdmcbain?

How does this reflect with your earlier tests on the eigenvalues? Do the conclusions still hold? I had to modify the test result a bit. I suppose we need some sort of convergence test for this operator.