### PR TITLE
define RHS using a restricted basis rather than a mask

### DIFF
--- a/docs/examples/ex17.py
+++ b/docs/examples/ex17.py
@@ -6,7 +6,7 @@ from pygmsh import generate_mesh
 from pygmsh.built_in import Geometry
 
 from skfem import *
-from skfem.models.poisson import mass
+from skfem.models.poisson import mass, unit_load
 from skfem.io import from_meshio
 
 radii = [2., 3.]
@@ -56,15 +56,8 @@ L = asm(conduction, basis, w=conductivity)
 facet_basis = FacetBasis(mesh, element, facets=mesh.boundaries['convection'])
 H = heat_transfer_coefficient * asm(convection, facet_basis)
 
-
-@linear_form
-def generation(v, dv, w):
-    return w.w * v
-
-
-heated = basis.zero_w()
-heated[mesh.subdomains['wire']] = 1.
-f = joule_heating * asm(generation, basis, w=heated)
+wire_basis = InteriorBasis(mesh, basis.elem, elements=mesh.subdomains['wire'])
+f = joule_heating * asm(unit_load, wire_basis)
 
 temperature = solve(L + H, f)
 


### PR DESCRIPTION
I think it makes more sense when there's a source term defined only in a subdomain to assemble it using a basis restricted to that subdomain, rather than everywhere and then multiply by zero outside that subdomain.

The `elements` kwarg wasn't available in `asm` until #166 (2019-04) whereas this example was written 2018-12.