### PR TITLE
select all essential dofs

### DIFF
--- a/docs/examples/ex24.py
+++ b/docs/examples/ex24.py
@@ -68,14 +68,12 @@ K = bmat([[A, -B.T],
 uvp = np.zeros(K.shape[0])
 
 inlet_basis = FacetBasis(mesh, element['u'], facets=mesh.boundaries['inlet'])
-inlet_dofs_ = inlet_basis.get_dofs(mesh.boundaries['inlet'])
-inlet_dofs = np.concatenate([inlet_dofs_.nodal[f'u^{1}'],
-                             inlet_dofs_.facet[f'u^{1}']])
+inlet_dofs = inlet_basis.get_dofs(mesh.boundaries['inlet']).all()
 
 
 def parabolic(x, y):
     """return the plane Poiseuille parabolic inlet profile"""
-    return ((4 * y * (1. - y), np.zeros_like(y)))
+    return 4 * y * (1. - y), np.zeros_like(y)
 
 
 uvp[inlet_dofs] = L2_projection(parabolic, inlet_basis, inlet_dofs)

--- a/docs/examples/ex27.py
+++ b/docs/examples/ex27.py
@@ -115,15 +115,13 @@ class BackwardFacingStep:
         return from_meshio(generate_mesh(geom, dim=2))
 
     def inlet_dofs(self):
-        inlet_dofs_ = self.basis['inlet'].get_dofs(
-            self.mesh.boundaries['inlet'])
-        return np.concatenate([inlet_dofs_.nodal[f'u^{1}'],
-                               inlet_dofs_.facet[f'u^{1}']])
+        return self.basis['inlet'].get_dofs(
+            self.mesh.boundaries['inlet']).all()
 
     @staticmethod
     def parabolic(x, y):
         """return the plane Poiseuille parabolic inlet profile"""
-        return ((4 * y * (1. - y), np.zeros_like(y)))
+        return 4 * y * (1. - y), np.zeros_like(y)
 
     def make_vector(self):
         """prepopulate solution vector with Dirichlet conditions"""

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -184,7 +184,7 @@ class TestEx27(TestCase):
    def runTest(self):
       import docs.examples.ex27 as ex
       _, psi = ex.psi.popitem()
-      self.assertAlmostEqual(min(psi), -0.02704307069920056)
+      self.assertAlmostEqual(min(psi), -0.027043, delta=1e-6)
       self.assertAlmostEqual(max(psi), 0.6668969079018402)
 
 


### PR DESCRIPTION
While leaning on ex24 for guidance in how to answer #357, I was puzzled as to why it was only selecting the _x_-components of velocity but apparently setting both _x_ and _y_.  I think this was accidentally harmless as the _y_ components were set to zero, but more generally I think either both components should be set (as here) or values only provided for those that are set.