### PR TITLE
Fix edge expansion in _get_dofs

### DIFF
--- a/skfem/assembly/basis/basis.py
+++ b/skfem/assembly/basis/basis.py
@@ -145,12 +145,24 @@ class Basis:
                   facets: ndarray,
                   skip: List[str] = []):
         """Return :class:`skfem.assembly.Dofs` corresponding to facets."""
-        nodal_ix = np.unique(self.mesh.facets[:, facets].flatten())
+        m = self.mesh
+        nodal_ix = np.unique(m.facets[:, facets].flatten())
         facet_ix = facets
-        edge_ix = np.intersect1d(
-            self.mesh.boundary_edges(),
-            np.unique(self.mesh.t2e[:, self.mesh.f2t[0, facets]].flatten())
-        ) if self.mesh.dim() == 3 else []
+
+        if m.dim() == 3:
+            edge_candidates = m.t2e[:, m.f2t[0, facets]].flatten()
+            # subset of edges that share all points with the given facets
+            subset_ix = np.nonzero(
+                np.prod(np.isin(m.edges[:, edge_candidates],
+                                m.facets[:, facets].flatten()),
+                        axis=0)
+            )[0]
+            edge_ix = np.intersect1d(
+                m.boundary_edges(),
+                edge_candidates[subset_ix]
+            )
+        else:
+            edge_ix = []
 
         n_nodal = self.nodal_dofs.shape[0]
         n_facet = self.facet_dofs.shape[0]

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -1,6 +1,7 @@
 from unittest import TestCase
 
 import numpy as np
+from numpy.testing import assert_allclose
 
 from skfem import *
 
@@ -55,3 +56,19 @@ class TestCompositeSplitting(TestCase):
         self.assertTrue('w^2' in y)
 
         self.assertTrue((basis.doflocs[:, D['up'].all()][1] == 1.).all())
+
+
+class TestFacetExpansion(TestCase):
+
+    def runTest(self):
+
+        m = MeshTet()
+
+        basis = InteriorBasis(m, ElementTetP2())
+
+        arr1 = basis.find_dofs({
+            'kek':m.facets_satisfying(lambda x: x[0] == 0)
+        })['kek'].edge['u']
+        arr2 = basis.edge_dofs[:, m.edges_satisfying(lambda x: x[0] == 0)]
+
+        assert_allclose(arr1, arr2.flatten())


### PR DESCRIPTION
Fixes  #83 .

The idea is to always compare that the resulting edges actually share points with the given facets. It was relatively easy to vectorize.