### PR TITLE
Use kwargs in asm for additional fields

### DIFF
--- a/skfem/assembly/basis/basis.py
+++ b/skfem/assembly/basis/basis.py
@@ -285,17 +285,18 @@ class Basis:
 
         Returns
         -------
-        Dict[str, DiscreteField]
+        DiscreteField or (DiscreteField, ...)
             The solution vector interpolated at quadrature points.
-            If Basis consist of a single component, the dictionary has
-            a single key 'w'. Otherwise, the keys are 'w^1', 'w^2', ...
+            If Basis consist of a single component, returns only
+            one DiscreteField. If Basis consists of multiple components,
+            returns a tuple.
 
         """
         if w.shape[0] != self.N:
             raise ValueError("Input array has wrong size.")
 
         refs = self.basis[0]
-        dfs: Dict[str, DiscreteField] = {}
+        dfs: List[DiscreteField] = []
 
         # loop over solution components
         for c in range(len(refs)):
@@ -351,11 +352,11 @@ class Basis:
                 for n in range(len(ref[-1])):
                     fs[-1].append(linear_combination(n, ref[-1][n]))
 
-            # give names for the interpolated fields
-            key = 'w' if len(refs) == 1 else 'w^' + str(c + 1)
-            dfs[key] = DiscreteField(*fs)
+            dfs.append(DiscreteField(*fs))
 
-        return dfs
+        if len(dfs) > 1:
+            return tuple(dfs)
+        return dfs[0]
 
     def split_indices(self) -> List[ndarray]:
         """Return indices for the solution components."""

--- a/skfem/assembly/form/bilinear_form.py
+++ b/skfem/assembly/form/bilinear_form.py
@@ -13,7 +13,7 @@ class BilinearForm(Form):
     def assemble(self,
                  u: Basis,
                  v: Optional[Basis] = None,
-                 w: Dict[str, DiscreteField] = {}) -> Any:
+                 **kwargs) -> Any:
 
         if v is None:
             v = u
@@ -23,7 +23,7 @@ class BilinearForm(Form):
 
         nt = u.nelems
         dx = u.dx
-        w = FormDict({**u.default_parameters(), **self.dictify(w)})
+        w = FormDict({**u.default_parameters(), **self.dictify(kwargs)})
 
         # initialize COO data structures
         sz = u.Nbfun * v.Nbfun * nt

--- a/skfem/assembly/form/form.py
+++ b/skfem/assembly/form/form.py
@@ -32,21 +32,20 @@ class Form:
     @staticmethod
     def dictify(w):
         """Support some legacy input formats for 'w'."""
-        if not isinstance(w, dict):
-            # TODO: deprecate
-            if isinstance(w, DiscreteField):
-                w = {'w': w}
-            elif isinstance(w, ndarray):
-                w = {'w': DiscreteField(w)}
-            elif isinstance(w, list):
-                w = {'w': DiscreteField(np.array([z['w'].f for z in w]),
-                                        np.array([z['w'].df for z in w]))}
-            elif isinstance(w, tuple):
-                w = {'w': DiscreteField(*w)}
+        for k in w:
+            if isinstance(w[k], DiscreteField):
+                continue
+            elif isinstance(w[k], ndarray):
+                w[k] = DiscreteField(w[k])
+            elif isinstance(w[k], list):
+                w[k] = DiscreteField(np.array([z.f for z in w[k]]),
+                                     np.array([z.df for z in w[k]]))
+            elif isinstance(w[k], tuple):
+                w[k] = DiscreteField(*w[k])
             else:
                 raise ValueError("The given type '{}' for the list of extra "
                                  "form parameters w cannot be converted to "
-                                 "Dict[str, DiscreteField].".format(type(w)))
+                                 "DiscreteField.".format(type(w)))
         return w
 
     @staticmethod

--- a/skfem/assembly/form/functional.py
+++ b/skfem/assembly/form/functional.py
@@ -17,14 +17,14 @@ class Functional(Form):
 
     def elemental(self,
                   v: Basis,
-                  w: Dict[str, DiscreteField] = {}) -> ndarray:
-        w = FormDict({**v.default_parameters(), **self.dictify(w)})
+                  **kwargs) -> ndarray:
+        w = FormDict({**v.default_parameters(), **self.dictify(kwargs)})
         return self._kernel(w, v.dx)
 
     def assemble(self,
                  v: Basis,
-                 w: Dict[str, DiscreteField] = {}) -> float:
-        return np.sum(self.elemental(v, w))
+                 **kwargs) -> float:
+        return np.sum(self.elemental(v, **kwargs))
 
 
 def functional(form: Callable) -> Functional:

--- a/skfem/assembly/form/linear_form.py
+++ b/skfem/assembly/form/linear_form.py
@@ -13,14 +13,14 @@ class LinearForm(Form):
     def assemble(self,
                  u: Basis,
                  v: Optional[Basis] = None,
-                 w: Dict[str, DiscreteField] = {}) -> ndarray:
+                 **kwargs) -> ndarray:
 
         assert v is None
         v = u
 
         nt = v.nelems
         dx = v.dx
-        w = FormDict({**v.default_parameters(), **self.dictify(w)})
+        w = FormDict({**v.default_parameters(), **self.dictify(kwargs)})
 
         # initialize COO data structures
         sz = v.Nbfun * nt

--- a/tests/test_assembly.py
+++ b/tests/test_assembly.py
@@ -288,5 +288,26 @@ class TestFieldInterpolation(unittest.TestCase):
         self.assertAlmostEqual(feqx.assemble(basis, func=func), 1.)
 
 
+class TestFieldInterpolation(unittest.TestCase):
+
+    def runTest(self):
+
+        m = MeshTri()
+        e = ElementTriP1()
+        basis = InteriorBasis(m, e)
+
+        @Functional
+        def feqx(w):
+            from skfem.helpers import grad
+            f = w['func']  # f(x, y) = x
+            g = w['gunc']  # g(x, y) = y
+            return grad(f)[0] + grad(g)[1]
+
+        func = basis.interpolate(m.p[0])
+        gunc = basis.interpolate(m.p[1])
+
+        self.assertAlmostEqual(feqx.assemble(basis, func=func, gunc=gunc), 2.)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -51,9 +51,9 @@ class TestCompositeSplitting(TestCase):
 
         self.assertTrue(np.sum(p - x[basis.nodal_dofs[2]]) < 1e-8)
 
-        y = basis.interpolate(x)
-        self.assertTrue('w^1' in y)
-        self.assertTrue('w^2' in y)
+        U, P = basis.interpolate(x)
+        self.assertTrue(isinstance(U.value, np.ndarray))
+        self.assertTrue(isinstance(P.value, np.ndarray))
 
         self.assertTrue((basis.doflocs[:, D['up'].all()][1] == 1.).all())
 

--- a/tests/test_convergence.py
+++ b/tests/test_convergence.py
@@ -65,7 +65,7 @@ class ConvergenceQ1(unittest.TestCase):
         self.assertLess(L2s[-1], 0.008)
 
     def compute_error(self, m, basis, U):
-        uh, duh, *_ = basis.interpolate(U)['w']
+        uh, duh, *_ = basis.interpolate(U)
         dx = basis.dx
         x = basis.global_coordinates()
 
@@ -336,7 +336,7 @@ class FacetConvergenceTetP2(unittest.TestCase):
         self.assertLess(L2err[-1], 0.005)
 
     def compute_error(self, m, basis, U):
-        uh, duh, *_ = basis.interpolate(U)['w']
+        uh, duh, *_ = basis.interpolate(U)
         dx = basis.dx
         x = basis.global_coordinates().f
 

--- a/tests/test_convergence_hdiv.py
+++ b/tests/test_convergence_hdiv.py
@@ -82,7 +82,7 @@ class ConvergenceRaviartThomas(unittest.TestCase):
         self.assertLess(L2s[-1], self.L2bound)
 
     def compute_L2(self, m, basis, U):
-        uh, *_ = basis.interpolate(U)['w']
+        uh, *_ = basis.interpolate(U)
         dx = basis.dx
         x = basis.global_coordinates()
 
@@ -99,7 +99,7 @@ class ConvergenceRaviartThomas(unittest.TestCase):
         return np.sqrt(np.sum(np.sum((uh - u(x.f)) ** 2 * dx, axis=1)))
 
     def compute_Hdiv(self, m, basis, U):
-        uh, duh, *_ = basis.interpolate(U)['w']
+        uh, duh, *_ = basis.interpolate(U)
         dx = basis.dx
         x = basis.global_coordinates()
 

--- a/tests/test_p_convergence.py
+++ b/tests/test_p_convergence.py
@@ -46,7 +46,7 @@ class ConvergenceLinePp(unittest.TestCase):
         self.assertLess(L2s[-1], 1e-13)
 
     def compute_error(self, m, basis, U):
-        uh, duh, *_ = basis.interpolate(U)['w']
+        uh, duh, *_ = basis.interpolate(U)
         dx = basis.dx
         x = basis.global_coordinates()
 
@@ -106,7 +106,7 @@ class ConvergenceQuadP(unittest.TestCase):
         self.assertLess(L2s[-1], 1e-11)
 
     def compute_error(self, m, basis, U):
-        uh, duh, *_ = basis.interpolate(U)['w']
+        uh, duh, *_ = basis.interpolate(U)
         dx = basis.dx
         x = basis.global_coordinates()
 


### PR DESCRIPTION
As proposed in https://github.com/kinnala/scikit-fem/pull/360#issuecomment-611193927 .

After all it seemed to work fine. So the principle is now that
```python
y = basis.interpolate(x)  # type: DiscreteField
```
and this gets passed to `asm` as keyword arguments:
```python
asm(bilinf, basis, test=y)
```
This assumes e.g.
```python
@BilinearForm
def bilinf(u, v, w):
    return u * v * w.test
```

Makes sense?