### PR TITLE
name coefficients passed to asm

### DIFF
--- a/docs/examples/ex13.py
+++ b/docs/examples/ex13.py
@@ -74,13 +74,13 @@ conductance = {'skfem': u @ A @ u,
 @Functional
 def port_flux(w):
     from skfem.helpers import dot, grad
-    return dot(w.n, grad(w['w']))
+    return dot(w.n, grad(w['u']))
 
 
 current = {}
 for port, boundary in mesh.boundaries.items():
     fbasis = FacetBasis(mesh, elements, facets=boundary)
-    current[port] = asm(port_flux, fbasis, w=fbasis.interpolate(u))
+    current[port] = asm(port_flux, fbasis, u=fbasis.interpolate(u))
 
 if __name__ == '__main__':
 

--- a/docs/examples/ex17.py
+++ b/docs/examples/ex17.py
@@ -69,7 +69,7 @@ mesh = make_mesh(*radii)
 
 @BilinearForm
 def conduction(u, v, w):
-    return dot(w.w * grad(u), grad(v))
+    return dot(w['conductivity'] * grad(u), grad(v))
 
 
 convection = mass
@@ -81,7 +81,7 @@ conductivity = basis.zero_w()
 for subdomain, elements in mesh.subdomains.items():
     conductivity[elements] = thermal_conductivity[subdomain]
 
-L = asm(conduction, basis, w=conductivity)
+L = asm(conduction, basis, conductivity=conductivity)
 
 facet_basis = FacetBasis(mesh, element, facets=mesh.boundaries['convection'])
 H = heat_transfer_coefficient * asm(convection, facet_basis)

--- a/docs/examples/ex27.py
+++ b/docs/examples/ex27.py
@@ -71,8 +71,8 @@ from pacopy import natural
 def acceleration(v, w):
     """Compute the vector (v, u . grad u) for given velocity u
 
-    passed in via w after having been interpolated onto its quadrature
-    points.
+    passed in via `wind` after having been interpolated onto its
+    quadrature points.
 
     In Cartesian tensorial indicial notation, the integrand is
 
@@ -81,8 +81,7 @@ def acceleration(v, w):
         u_j u_{i,j} v_i.
 
     """
-    u = w['w']
-    return np.einsum('j...,ij...,i...', u, grad(u), v)
+    return np.einsum('j...,ij...,i...', w['wind'], grad(w['wind']), v)
 
 
 @BilinearForm
@@ -99,8 +98,8 @@ def acceleration_jacobian(u, v, w):
        (w_j du_{i,j} + u_j dw_{i,j}) v_i
 
     """
-    return dot(np.einsum('j...,ij...->i...', w['w'], grad(u))
-               + np.einsum('j...,ij...->i...', u, grad(w['w'])), v)
+    return dot(np.einsum('j...,ij...->i...', w['wind'], grad(u))
+               + np.einsum('j...,ij...->i...', u, grad(w['wind'])), v)
 
 
 class BackwardFacingStep:
@@ -236,7 +235,7 @@ class BackwardFacingStep:
 
     def N(self, uvp: np.ndarray) -> np.ndarray:
         u = self.basis['u'].interpolate(self.split(uvp)[0])
-        return np.hstack([asm(acceleration, self.basis['u'], w=u),
+        return np.hstack([asm(acceleration, self.basis['u'], wind=u),
                           np.zeros(self.basis['p'].N)])
 
     def f(self, uvp: np.ndarray, reynolds: float) -> np.ndarray:
@@ -259,7 +258,7 @@ class BackwardFacingStep:
         duvp = solve(*condense(
             self.S +
             reynolds
-            * block_diag([asm(acceleration_jacobian, self.basis['u'], w=u),
+            * block_diag([asm(acceleration_jacobian, self.basis['u'], wind=u),
                           csr_matrix((self.basis['p'].N,)*2)]),
             rhs, self.make_vector() - uvp, I=self.I))
         return duvp

--- a/docs/examples/ex28.py
+++ b/docs/examples/ex28.py
@@ -131,7 +131,7 @@ basis = {
 
 @BilinearForm
 def conduction(u, v, w):
-    return dot(w['w'] * grad(u), grad(v))
+    return dot(w['conductivity'] * grad(u), grad(v))
 
 
 @BilinearForm
@@ -145,7 +145,7 @@ conductivity[mesh.subdomains['solid']] = kratio
 
 longitudinal_gradient = 3 / 4 / peclet
 
-A = (asm(conduction, basis['heat'], w=conductivity)
+A = (asm(conduction, basis['heat'], conductivity=conductivity)
      + peclet * asm(advection, basis['fluid']))
 b = (asm(unit_load, basis['heated'])
      + longitudinal_gradient

--- a/docs/examples/ex32.py
+++ b/docs/examples/ex32.py
@@ -113,7 +113,7 @@ class Ellipsoid(NamedTuple):
     def pressure_error(self):
 
         def form(v, w):
-            return v * (w.w - self.pressure(*w.x))
+            return v * (w['p'] - self.pressure(*w.x))
 
         return LinearForm(form)
 
@@ -163,7 +163,7 @@ velocity, pressure = np.split(
     [basis['u'].N])
 
 error_p = asm(ellipsoid.pressure_error(), basis['p'],
-              w=basis['p'].interpolate(pressure))
+              p=basis['p'].interpolate(pressure))
 l2error_p = np.sqrt(error_p.T @ Q @ error_p)
 
 if __name__ == '__main__':


### PR DESCRIPTION
I needed to pass two coefficients to a new-style BilinearForm but didn't know how (previously with the old-style `bilinear_form` I had cheated by passing a pair as `w`).  Then I remembered that they didn't have to both be passed in via `w`, that any number of kwargs could be passed to `asm`.  I thought it might be a good idea to demonstrate this idiom in some of the examples.