### PR TITLE
Update assembly/__init__.py: fix flake8 errors

### DIFF
--- a/skfem/assembly/__init__.py
+++ b/skfem/assembly/__init__.py
@@ -62,3 +62,16 @@ def asm(form: Form,
 
     """
     return form.assemble(*args, **kwargs)
+
+
+__all__ = [
+    "Basis",
+    "InteriorBasis",
+    "FacetBasis",
+    "Dofs",
+    "BilinearForm",
+    "LinearForm",
+    "Functional",
+    "bilinear_form",
+    "linear_form",
+    "functional"]


### PR DESCRIPTION
Fixes the following flake8 errors in `skfem/assembly/__init__.py`:

- '.basis.Basis' imported but unused
- '.basis.InteriorBasis' imported but unused
- '.basis.FacetBasis' imported but unused
- '.dofs.Dofs' imported but unused
- '.form.BilinearForm' imported but unused
- '.form.LinearForm' imported but unused
- '.form.Functional' imported but unused
- '.form.bilinear_form' imported but unused
- '.form.linear_form' imported but unused
- '.form.functional' imported but unused