### PR TITLE
Update mesh/mesh3d/mesh3d.py: fix flake8 errors

### DIFF
--- a/skfem/mesh/mesh3d/mesh3d.py
+++ b/skfem/mesh/mesh3d/mesh3d.py
@@ -35,9 +35,10 @@ class Mesh3D(Mesh):
         facets = self.boundary_facets()
         boundary_edges = np.sort(np.hstack(
             tuple([np.vstack((self.facets[itr, facets],
-                              self.facets[(itr + 1) % self.facets.shape[0], facets]))\
+                              self.facets[(itr + 1) % self.facets.shape[0],
+                              facets]))
                    for itr in range(self.facets.shape[0])])).T, axis=1)
-        return np.nonzero((self.edges.T[:, None] == boundary_edges)\
+        return np.nonzero((self.edges.T[:, None] == boundary_edges)
                           .all(-1).any(-1))[0]
 
     def interior_edges(self) -> ndarray:
@@ -47,5 +48,6 @@ class Mesh3D(Mesh):
 
     def param(self) -> float:
         """Return mesh parameter, viz the length of the longest edge."""
-        lengths = np.linalg.norm(np.diff(self.p[:, self.edges], axis=1), axis=0)
+        lengths = np.linalg.norm(
+            np.diff(self.p[:, self.edges], axis=1), axis=0)
         return np.max(lengths)


### PR DESCRIPTION
Running `flake8 skfem/mesh/mesh3d/mesh3d.py`:

skfem/mesh/mesh3d/mesh3d.py:38:80: E501 line too long (86 > 79 characters)
skfem/mesh/mesh3d/mesh3d.py:38:86: E502 the backslash is redundant between brackets
skfem/mesh/mesh3d/mesh3d.py:40:68: E502 the backslash is redundant between brackets
skfem/mesh/mesh3d/mesh3d.py:50:80: E501 line too long (80 > 79 characters)

-> fixed