### PR TITLE
Fix flake8 errors on skfem/helpers.py

### DIFF
--- a/skfem/helpers.py
+++ b/skfem/helpers.py
@@ -49,9 +49,16 @@ def sym_grad(u: DiscreteField):
     return .5 * (u.grad + transpose(u.grad))
 
 
-dd = lambda u: u.hess
-ddd = lambda u: u.hod[0]
-dddd = lambda u: u.hod[1]
+def dd(u):
+    return u.hess
+
+
+def ddd(u):
+    return u.hod[0]
+
+
+def dddd(u):
+    return u.hod[1]
 
 
 def dot(u: FieldOrArray, v: FieldOrArray):


### PR DESCRIPTION
skfem/helpers.py:52:1: E731 do not assign a lambda expression, use a def
skfem/helpers.py:53:1: E731 do not assign a lambda expression, use a def
skfem/helpers.py:54:1: E731 do not assign a lambda expression, use a def

Fixed.