### PR TITLE
Fix flake8 errors in tests/test_visuals.py

### DIFF
--- a/tests/test_visuals.py
+++ b/tests/test_visuals.py
@@ -1,7 +1,7 @@
 import unittest
 
-from skfem.mesh import *
-from skfem.visuals.matplotlib import *
+from skfem.mesh import MeshTri, MeshQuad, MeshTet, MeshLine
+from skfem.visuals.matplotlib import draw, plot, plot3
 
 
 class CallDraw(unittest.TestCase):


### PR DESCRIPTION
```
test_visuals.py:3:1: F403 'from skfem.mesh import *' used; unable to detect undefined names
test_visuals.py:4:1: F403 'from skfem.visuals.matplotlib import *' used; unable to detect undefined names
test_visuals.py:8:17: F405 'MeshTri' may be undefined, or defined from star imports: skfem.mesh, skfem.visuals.matplotlib
test_visuals.py:12:9: F405 'draw' may be undefined, or defined from star imports: skfem.mesh, skfem.visuals.matplotlib
test_visuals.py:16:17: F405 'MeshQuad' may be undefined, or defined from star imports: skfem.mesh, skfem.visuals.matplotlib
test_visuals.py:20:17: F405 'MeshTet' may be undefined, or defined from star imports: skfem.mesh, skfem.visuals.matplotlib
test_visuals.py:24:17: F405 'MeshTri' may be undefined, or defined from star imports: skfem.mesh, skfem.visuals.matplotlib
test_visuals.py:28:9: F405 'plot' may be undefined, or defined from star imports: skfem.mesh, skfem.visuals.matplotlib
test_visuals.py:32:17: F405 'MeshQuad' may be undefined, or defined from star imports: skfem.mesh, skfem.visuals.matplotlib
test_visuals.py:36:17: F405 'MeshLine' may be undefined, or defined from star imports: skfem.mesh, skfem.visuals.matplotlib
test_visuals.py:40:17: F405 'MeshTri' may be undefined, or defined from star imports: skfem.mesh, skfem.visuals.matplotlib
test_visuals.py:44:9: F405 'plot3' may be undefined, or defined from star imports: skfem.mesh, skfem.visuals.matplotlib
```

Fixed.