### PR TITLE
Fix flake8 errors in tests/test_p_convergence.py

### DIFF
--- a/tests/test_p_convergence.py
+++ b/tests/test_p_convergence.py
@@ -2,7 +2,9 @@ import unittest
 
 import numpy as np
 
-from skfem import *
+from skfem import (MeshLine, ElementLinePp, InteriorBasis, LinearForm, asm,
+                   solve, condense, MeshQuad, ElementQuadP)
+
 from skfem.models.poisson import laplace
 
 


### PR DESCRIPTION
```
tests/test_p_convergence.py:5:1: F403 'from skfem import *' used; unable to detect undefined names
tests/test_p_convergence.py:13:21: F405 'MeshLine' may be undefined, or defined from star imports: skfem
tests/test_p_convergence.py:17:13: F405 'ElementLinePp' may be undefined, or defined from star imports: skfem
tests/test_p_convergence.py:18:16: F405 'InteriorBasis' may be undefined, or defined from star imports: skfem
tests/test_p_convergence.py:22:10: F405 'LinearForm' may be undefined, or defined from star imports: skfem
tests/test_p_convergence.py:35:17: F405 'asm' may be undefined, or defined from star imports: skfem
tests/test_p_convergence.py:36:17: F405 'asm' may be undefined, or defined from star imports: skfem
tests/test_p_convergence.py:40:17: F405 'solve' may be undefined, or defined from star imports: skfem
tests/test_p_convergence.py:40:24: F405 'condense' may be undefined, or defined from star imports: skfem
tests/test_p_convergence.py:70:21: F405 'MeshQuad' may be undefined, or defined from star imports: skfem
tests/test_p_convergence.py:76:13: F405 'ElementQuadP' may be undefined, or defined from star imports: skfem
tests/test_p_convergence.py:77:16: F405 'InteriorBasis' may be undefined, or defined from star imports: skfem
tests/test_p_convergence.py:81:10: F405 'LinearForm' may be undefined, or defined from star imports: skfem
tests/test_p_convergence.py:95:17: F405 'asm' may be undefined, or defined from star imports: skfem
tests/test_p_convergence.py:96:17: F405 'asm' may be undefined, or defined from star imports: skfem
tests/test_p_convergence.py:100:17: F405 'solve' may be undefined, or defined from star imports: skfem
tests/test_p_convergence.py:100:24: F405 'condense' may be undefined, or defined from star imports: skfem
```

Fixed.