### PR TITLE
Fix flake8 errors in file tests/test_mesh.py

### DIFF
--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import numpy as np
 
-from skfem.mesh import *
+from skfem.mesh import Mesh, MeshHex, MeshLine, MeshQuad, MeshTet, MeshTri
 
 
 class MeshTests(unittest.TestCase):
@@ -41,20 +41,20 @@ class FaultyInputs(unittest.TestCase):
     def runTest(self):
         with self.assertRaises(Exception):
             # point belonging to no element
-            m = MeshTri(np.array([[0, 0], [0, 1], [1, 0], [1, 1]]).T,
-                        np.array([[0, 1, 2]]).T)
+            MeshTri(np.array([[0, 0], [0, 1], [1, 0], [1, 1]]).T,
+                    np.array([[0, 1, 2]]).T)
         with self.assertRaises(Exception):
             # wrong size inputs (t not matching to Mesh type)
-            m = MeshTet(np.array([[0, 0], [0, 1], [1, 0], [1, 1]]).T,
-                        np.array([[0, 1, 2]]).T)
+            MeshTet(np.array([[0, 0], [0, 1], [1, 0], [1, 1]]).T,
+                    np.array([[0, 1, 2]]).T)
         with self.assertRaises(Exception):
             # inputting trasposes
-            m = MeshTri(np.array([[0, 0], [0, 1], [1, 0], [1, 1]]),
-                        np.array([[0, 1, 2], [1, 2, 3]]))
+            MeshTri(np.array([[0, 0], [0, 1], [1, 0], [1, 1]]),
+                    np.array([[0, 1, 2], [1, 2, 3]]))
         with self.assertRaises(Exception):
             # floats in element connectivity
-            m = MeshTri(np.array([[0, 0], [0, 1], [1, 0], [1, 1]]).T,
-                        np.array([[0.0, 1.0, 2.0], [1.0, 2.0, 3.0]]).T)
+            MeshTri(np.array([[0, 0], [0, 1], [1, 0], [1, 1]]).T,
+                    np.array([[0.0, 1.0, 2.0], [1.0, 2.0, 3.0]]).T)
 
 
 class Loading(unittest.TestCase):
@@ -92,12 +92,14 @@ class RefinePreserveSubsets(unittest.TestCase):
                 m.define_boundary(name, handle, boundaries_only=False)
             m.refine()
             for name, handle in boundaries:
-                self.assertTrue((np.sort(m.boundaries[name])
-                                 == np.sort(m.facets_satisfying(handle))).all())
+                A = np.sort(m.boundaries[name])
+                B = np.sort(m.facets_satisfying(handle))
+                self.assertTrue((A == B).all())
             m.refine(2)
             for name, handle in boundaries:
-                self.assertTrue((np.sort(m.boundaries[name])
-                                 == np.sort(m.facets_satisfying(handle))).all())
+                A = np.sort(m.boundaries[name])
+                B = np.sort(m.facets_satisfying(handle))
+                self.assertTrue((A == B).all())
 
 
 class SaveLoadCycle(unittest.TestCase):
@@ -149,7 +151,8 @@ class TestBoundaryEdges(unittest.TestCase):
         self.assertEqual(len(m.boundary_edges()), m.edges.shape[1])
         m.refine()
         # check that there is a correct amount of boundary edges:
-        # 12 (cube edges) * 2 (per cube edge) + 6 (cube faces) * 8 (per cube face)
+        # 12 (cube edges) * 2 (per cube edge)
+        # + 6 (cube faces) * 8 (per cube face)
         # = 72 edges
         self.assertTrue(len(m.boundary_edges()) == 72)
 
@@ -162,7 +165,8 @@ class TestBoundaryEdges2(unittest.TestCase):
         self.assertTrue(len(m.boundary_edges()) == m.edges.shape[1])
         m.refine()
         # check that there is a correct amount of boundary edges:
-        # 12 (cube edges) * 2 (per cube edge) + 6 (cube faces) * 4 (per cube face)
+        # 12 (cube edges) * 2 (per cube edge)
+        # + 6 (cube faces) * 4 (per cube face)
         # = 48 edges
         self.assertEqual(len(m.boundary_edges()), 48)
 


### PR DESCRIPTION
```
tests/test_mesh.py:6:1: F403 'from skfem.mesh import *' used; unable to detect undefined names
tests/test_mesh.py:15:13: F405 'MeshTri' may be undefined, or defined from star imports: skfem.mesh
tests/test_mesh.py:29:13: F405 'MeshHex' may be undefined, or defined from star imports: skfem.mesh
tests/test_mesh.py:44:17: F405 'MeshTri' may be undefined, or defined from star imports: skfem.mesh
tests/test_mesh.py:48:17: F405 'MeshTet' may be undefined, or defined from star imports: skfem.mesh
tests/test_mesh.py:52:17: F405 'MeshTri' may be undefined, or defined from star imports: skfem.mesh
tests/test_mesh.py:56:13: F841 local variable 'm' is assigned to but never used
tests/test_mesh.py:56:17: F405 'MeshTri' may be undefined, or defined from star imports: skfem.mesh
tests/test_mesh.py:66:13: F405 'MeshTet' may be undefined, or defined from star imports: skfem.mesh
tests/test_mesh.py:73:13: F405 'MeshTri' may be undefined, or defined from star imports: skfem.mesh
tests/test_mesh.py:86:23: F405 'MeshLine' may be undefined, or defined from star imports: skfem.mesh
tests/test_mesh.py:86:33: F405 'MeshTri' may be undefined, or defined from star imports: skfem.mesh
tests/test_mesh.py:86:42: F405 'MeshQuad' may be undefined, or defined from star imports: skfem.mesh
tests/test_mesh.py:96:80: E501 line too long (80 > 79 characters)
tests/test_mesh.py:100:80: E501 line too long (80 > 79 characters)
tests/test_mesh.py:105:11: F405 'MeshTet' may be undefined, or defined from star imports: skfem.mesh
tests/test_mesh.py:114:18: F405 'Mesh' may be undefined, or defined from star imports: skfem.mesh
tests/test_mesh.py:119:11: F405 'MeshHex' may be undefined, or defined from star imports: skfem.mesh
tests/test_mesh.py:124:13: F405 'MeshTet' may be undefined, or defined from star imports: skfem.mesh
tests/test_mesh.py:125:13: F405 'MeshTri' may be undefined, or defined from star imports: skfem.mesh
tests/test_mesh.py:126:13: F405 'MeshHex' may be undefined, or defined from star imports: skfem.mesh
tests/test_mesh.py:127:13: F405 'MeshQuad' may be undefined, or defined from star imports: skfem.mesh
tests/test_mesh.py:147:13: F405 'MeshTet' may be undefined, or defined from star imports: skfem.mesh
tests/test_mesh.py:152:80: E501 line too long (82 > 79 characters)
tests/test_mesh.py:160:13: F405 'MeshHex' may be undefined, or defined from star imports: skfem.mesh
tests/test_mesh.py:165:80: E501 line too long (82 > 79 characters)
tests/test_mesh.py:173:13: F405 'MeshTri' may be undefined, or defined from star imports: skfem.mesh
tests/test_mesh.py:174:13: F405 'MeshTri' may be undefined, or defined from star imports: skfem.mesh
tests/test_mesh.py:200:16: F405 'MeshQuad' may be undefined, or defined from star imports: skfem.mesh
```