### PR TITLE
Update tests/test_mapping.py: fix flake8 errors

### DIFF
--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -1,7 +1,10 @@
 import unittest
 import numpy as np
 
-from skfem import *
+from skfem.mesh import MeshHex, MeshQuad, MeshTri
+from skfem.element import ElementHex1, ElementQuad1
+from skfem.assembly import FacetBasis
+from skfem.mapping.mapping_mortar import MappingMortar
 
 
 class TestIsoparamNormals(unittest.TestCase):
@@ -19,10 +22,11 @@ class TestIsoparamNormals(unittest.TestCase):
         for itr in range(m.p.shape[0]):
             case = (x[itr] < eps) * (x[itr] > -eps)
             for jtr in range(m.p.shape[0]):
+                normals = fb.normals.f[jtr][case]
                 if itr == jtr:
-                    self.assertTrue((fb.normals.f[jtr][case] == -1).all())
+                    self.assertTrue((normals == -1).all())
                 else:
-                    self.assertTrue((np.abs(fb.normals.f[jtr][case]) < 1e-14).all())
+                    self.assertTrue((np.abs(normals) < 1e-14).all())
 
 
 class TestIsoparamNormalsQuad(TestIsoparamNormals):


### PR DESCRIPTION
```
tests/test_mapping.py:4:1: F403 'from skfem import *' used; unable to detect undefined names
tests/test_mapping.py:9:12: F405 'MeshHex' may be undefined, or defined from star imports: skfem
tests/test_mapping.py:10:12: F405 'ElementHex1' may be undefined, or defined from star imports: skfem
tests/test_mapping.py:16:14: F405 'FacetBasis' may be undefined, or defined from star imports: skfem
tests/test_mapping.py:25:80: E501 line too long (84 > 79 characters)
tests/test_mapping.py:29:12: F405 'MeshQuad' may be undefined, or defined from star imports: skfem
tests/test_mapping.py:30:12: F405 'ElementQuad1' may be undefined, or defined from star imports: skfem
tests/test_mapping.py:36:15: F405 'ElementQuad1' may be undefined, or defined from star imports: skfem
tests/test_mapping.py:39:14: F405 'MeshQuad' may be undefined, or defined from star imports: skfem
tests/test_mapping.py:40:13: F405 'MeshQuad' may be undefined, or defined from star imports: skfem
tests/test_mapping.py:51:14: F405 'FacetBasis' may be undefined, or defined from star imports: skfem
tests/test_mapping.py:61:15: F405 'ElementHex1' may be undefined, or defined from star imports: skfem
tests/test_mapping.py:64:14: F405 'MeshHex' may be undefined, or defined from star imports: skfem
tests/test_mapping.py:65:13: F405 'MeshHex' may be undefined, or defined from star imports: skfem
tests/test_mapping.py:79:18: F405 'MeshTri' may be undefined, or defined from star imports: skfem
tests/test_mapping.py:80:18: F405 'MeshTri' may be undefined, or defined from star imports: skfem
tests/test_mapping.py:95:14: F405 'MappingMortar' may be undefined, or defined from star imports: skfem
tests/test_mapping.py:105:18: F405 'MeshTri' may be undefined, or defined from star imports: skfem
tests/test_mapping.py:106:18: F405 'MeshQuad' may be undefined, or defined from star imports: skfem
tests/test_mapping.py:110:18: F405 'MeshQuad' may be undefined, or defined from star imports: skfem
tests/test_mapping.py:111:18: F405 'MeshQuad' may be undefined, or defined from star imports: skfem
tests/test_mapping.py:115:18: F405 'MeshQuad' may be undefined, or defined from star imports: skfem
tests/test_mapping.py:116:18: F405 'MeshTri' may be undefined, or defined from star imports: skfem
tests/test_mapping.py:121:18: F405 'MeshQuad' may be undefined, or defined from star imports: skfem
tests/test_mapping.py:122:18: F405 'MeshTri' may be undefined, or defined from star imports: skfem
```