### PR TITLE
Update tests/test_examples: fix flake8 errors

### DIFF
--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,4 +1,4 @@
-from unittest import TestCase
+from unittest import TestCase, main
 
 import numpy as np
 
@@ -48,7 +48,7 @@ class TestEx07(TestCase):
 
 class TestEx08(TestCase):
     def runTest(self):
-        import docs.examples.ex08 as ex08
+        import docs.examples.ex08 as ex08  # noqa
         # only run the initialization, nothing to test
 
 
@@ -114,19 +114,19 @@ class TestEx16(TestCase):
 
 class TestEx17(TestCase):
     def runTest(self):
-        import docs.examples.ex17 as ex
+        import docs.examples.ex17 as ex  # noqa
         # TODO improve
 
 
 class TestEx18(TestCase):
     def runTest(self):
-        import docs.examples.ex18 as ex
+        import docs.examples.ex18 as ex  # noqa
         # TODO improve
 
 
 class TestEx19(TestCase):
     def runTest(self):
-        import docs.examples.ex19 as ex
+        import docs.examples.ex19 as ex  # noqa
         # TODO improve
 
 
@@ -156,15 +156,15 @@ class TestEx22(TestCase):
 
 
 class TestEx23(TestCase):
-   def runTest(self):
-      import docs.examples.ex23 as ex
-      self.assertAlmostEqual(max(ex.lmbda_list), ex.turning_point,
-                             delta=5e-5)
+    def runTest(self):
+        import docs.examples.ex23 as ex
+        self.assertAlmostEqual(max(ex.lmbda_list), ex.turning_point,
+                               delta=5e-5)
 
 
 class TestEx24(TestCase):
     def runTest(self):
-        import docs.examples.ex24 as ex24
+        import docs.examples.ex24 as ex24  # noqa
 
 
 class TestEx25(TestCase):
@@ -177,15 +177,15 @@ class TestEx25(TestCase):
 
 class TestEx26(TestCase):
     def runTest(self):
-        import docs.examples.ex26 as ex26
+        import docs.examples.ex26 as ex26  # noqa
 
 
 class TestEx27(TestCase):
-   def runTest(self):
-      import docs.examples.ex27 as ex
-      _, psi = ex.psi.popitem()
-      self.assertAlmostEqual(min(psi), -0.027043, delta=1e-6)
-      self.assertAlmostEqual(max(psi), 0.6668, delta=1e-5)
+    def runTest(self):
+        import docs.examples.ex27 as ex
+        _, psi = ex.psi.popitem()
+        self.assertAlmostEqual(min(psi), -0.027043, delta=1e-6)
+        self.assertAlmostEqual(max(psi), 0.6668, delta=1e-5)
 
 
 class TestEx28(TestCase):


### PR DESCRIPTION
```
tests/test_examples.py:51:9: F401 'docs.examples.ex08' imported but unused
tests/test_examples.py:117:9: F401 'docs.examples.ex17 as ex' imported but unused
tests/test_examples.py:123:9: F401 'docs.examples.ex18 as ex' imported but unused
tests/test_examples.py:129:9: F401 'docs.examples.ex19 as ex' imported but unused
tests/test_examples.py:159:4: E111 indentation is not a multiple of four
tests/test_examples.py:160:7: E111 indentation is not a multiple of four
tests/test_examples.py:161:7: E111 indentation is not a multiple of four
tests/test_examples.py:167:9: F401 'docs.examples.ex24' imported but unused
tests/test_examples.py:180:9: F401 'docs.examples.ex26' imported but unused
tests/test_examples.py:184:4: E111 indentation is not a multiple of four
tests/test_examples.py:185:7: E111 indentation is not a multiple of four
tests/test_examples.py:186:7: E111 indentation is not a multiple of four
tests/test_examples.py:187:7: E111 indentation is not a multiple of four
tests/test_examples.py:188:7: E111 indentation is not a multiple of four
tests/test_examples.py:242:5: F821 undefined name 'main'
```