### PR TITLE
Update tests/test_convergence_h2.py: fix flake8 errors

### DIFF
--- a/tests/test_convergence_h2.py
+++ b/tests/test_convergence_h2.py
@@ -1,6 +1,11 @@
 import unittest
-from skfem import *
-from skfem.helpers import *
+import numpy as np
+
+from skfem import BilinearForm, LinearForm, Functional, asm, condense, solve
+from skfem.helpers import dd, ddot
+from skfem.mesh import MeshQuad, MeshTri
+from skfem.element import ElementQuadBFS, ElementTriArgyris, ElementTriMorley
+from skfem.assembly import InteriorBasis
 
 
 class ConvergenceMorley(unittest.TestCase):


### PR DESCRIPTION
```
test_convergence_h2.py:2:1: F403 'from skfem import *' used; unable to detect undefined names
test_convergence_h2.py:3:1: F403 'from skfem.helpers import *' used; unable to detect undefined names
test_convergence_h2.py:8:13: F405 'MeshTri' may be undefined, or defined from star imports: skfem, skfem.helpers
test_convergence_h2.py:8:22: F405 'ElementTriMorley' may be undefined, or defined from star imports: skfem, skfem.helpers
test_convergence_h2.py:22:18: F405 'InteriorBasis' may be undefined, or defined from star imports: skfem, skfem.helpers
test_convergence_h2.py:29:14: F405 'BilinearForm' may be undefined, or defined from star imports: skfem, skfem.helpers
test_convergence_h2.py:35:25: F405 'np' may be undefined, or defined from star imports: skfem, skfem.helpers
test_convergence_h2.py:38:40: F405 'ddot' may be undefined, or defined from star imports: skfem, skfem.helpers
test_convergence_h2.py:38:47: F405 'dd' may be undefined, or defined from star imports: skfem, skfem.helpers
test_convergence_h2.py:38:55: F405 'dd' may be undefined, or defined from star imports: skfem, skfem.helpers
test_convergence_h2.py:41:24: F405 'np' may be undefined, or defined from star imports: skfem, skfem.helpers
test_convergence_h2.py:41:31: F405 'np' may be undefined, or defined from star imports: skfem, skfem.helpers
test_convergence_h2.py:41:47: F405 'np' may be undefined, or defined from star imports: skfem, skfem.helpers
test_convergence_h2.py:41:54: F405 'np' may be undefined, or defined from star imports: skfem, skfem.helpers
test_convergence_h2.py:43:14: F405 'LinearForm' may be undefined, or defined from star imports: skfem, skfem.helpers
test_convergence_h2.py:47:17: F405 'asm' may be undefined, or defined from star imports: skfem, skfem.helpers
test_convergence_h2.py:48:17: F405 'asm' may be undefined, or defined from star imports: skfem, skfem.helpers
test_convergence_h2.py:53:17: F405 'solve' may be undefined, or defined from star imports: skfem, skfem.helpers
test_convergence_h2.py:53:24: F405 'condense' may be undefined, or defined from star imports: skfem, skfem.helpers
test_convergence_h2.py:58:39: F405 'np' may be undefined, or defined from star imports: skfem, skfem.helpers
test_convergence_h2.py:60:14: F405 'Functional' may be undefined, or defined from star imports: skfem, skfem.helpers
test_convergence_h2.py:64:18: F405 'np' may be undefined, or defined from star imports: skfem, skfem.helpers
test_convergence_h2.py:70:14: F405 'np' may be undefined, or defined from star imports: skfem, skfem.helpers
test_convergence_h2.py:71:15: F405 'np' may be undefined, or defined from star imports: skfem, skfem.helpers
test_convergence_h2.py:72:16: F405 'np' may be undefined, or defined from star imports: skfem, skfem.helpers
test_convergence_h2.py:72:27: F405 'np' may be undefined, or defined from star imports: skfem, skfem.helpers
test_convergence_h2.py:72:41: F405 'np' may be undefined, or defined from star imports: skfem, skfem.helpers
test_convergence_h2.py:80:13: F405 'MeshTri' may be undefined, or defined from star imports: skfem, skfem.helpers
test_convergence_h2.py:80:22: F405 'ElementTriArgyris' may be undefined, or defined from star imports: skfem, skfem.helpers
test_convergence_h2.py:88:13: F405 'MeshQuad' may be undefined, or defined from star imports: skfem, skfem.helpers
test_convergence_h2.py:88:23: F405 'ElementQuadBFS' may be undefined, or defined from star imports: skfem, skfem.helpers
```