### PR TITLE
Update tests/test_convergence.py: fix flake8 errors

### DIFF
--- a/tests/test_convergence.py
+++ b/tests/test_convergence.py
@@ -2,8 +2,15 @@ import unittest
 
 import numpy as np
 
-from skfem import *
+from skfem import BilinearForm, LinearForm, asm, solve, condense
 from skfem.models.poisson import laplace
+from skfem.element import (ElementHex1, ElementHexS2, ElementLineP1,
+                           ElementLineP2, ElementQuad1, ElementQuad2,
+                           ElementQuadS2, ElementTetMini, ElementTetP1,
+                           ElementTetP2, ElementTriMini, ElementTriP1,
+                           ElementTriP2)
+from skfem.assembly import FacetBasis, InteriorBasis
+from skfem.mesh import MeshHex, MeshLine, MeshQuad, MeshTet, MeshTri
 
 
 class ConvergenceQ1(unittest.TestCase):
@@ -35,7 +42,7 @@ class ConvergenceQ1(unittest.TestCase):
         hs = np.zeros(Nitrs)
 
         for itr in range(Nitrs):
-            if itr>0:
+            if itr > 0:
                 m.refine()
             ib = self.create_basis(m)
 
@@ -115,12 +122,15 @@ class ConvergenceQ1(unittest.TestCase):
         if m.dim() == 3:
             H1 = np.sqrt(np.sum(np.sum(((duh[0] - ux(x.f)) ** 2 +
                                         (duh[1] - uy(x.f)) ** 2 +
-                                        (duh[2] - uz(x.f)) ** 2) * dx, axis=1)))
+                                        (duh[2] - uz(x.f)) ** 2) * dx,
+                                axis=1)))
         elif m.dim() == 2:
             H1 = np.sqrt(np.sum(np.sum(((duh[0] - ux(x.f)) ** 2 +
-                                        (duh[1] - uy(x.f)) ** 2) * dx, axis=1)))
+                                        (duh[1] - uy(x.f)) ** 2) * dx,
+                                axis=1)))
         else:
-            H1 = np.sqrt(np.sum(np.sum(((duh[0] - ux(x.f)) ** 2) * dx, axis=1)))
+            H1 = np.sqrt(np.sum(np.sum(((duh[0] - ux(x.f)) ** 2) * dx,
+                                axis=1)))
 
         return L2, H1
 


### PR DESCRIPTION
```
tests/test_convergence.py:5:1: F403 'from skfem import *' used; unable to detect undefined names
tests/test_convergence.py:16:10: F405 'LinearForm' may be undefined, or defined from star imports: skfem
tests/test_convergence.py:38:19: E225 missing whitespace around operator
tests/test_convergence.py:42:17: F405 'asm' may be undefined, or defined from star imports: skfem
tests/test_convergence.py:43:17: F405 'asm' may be undefined, or defined from star imports: skfem
tests/test_convergence.py:46:17: F405 'solve' may be undefined, or defined from star imports: skfem
tests/test_convergence.py:46:24: F405 'condense' may be undefined, or defined from star imports: skfem
tests/test_convergence.py:118:80: E501 line too long (80 > 79 characters)
tests/test_convergence.py:121:80: E501 line too long (80 > 79 characters)
tests/test_convergence.py:123:80: E501 line too long (80 > 79 characters)
tests/test_convergence.py:128:13: F405 'ElementQuad1' may be undefined, or defined from star imports: skfem
tests/test_convergence.py:129:16: F405 'InteriorBasis' may be undefined, or defined from star imports: skfem
tests/test_convergence.py:132:21: F405 'MeshQuad' may be undefined, or defined from star imports: skfem
tests/test_convergence.py:141:13: F405 'ElementQuad2' may be undefined, or defined from star imports: skfem
tests/test_convergence.py:142:16: F405 'InteriorBasis' may be undefined, or defined from star imports: skfem
tests/test_convergence.py:145:21: F405 'MeshQuad' may be undefined, or defined from star imports: skfem
tests/test_convergence.py:152:13: F405 'ElementQuadS2' may be undefined, or defined from star imports: skfem
tests/test_convergence.py:153:16: F405 'InteriorBasis' may be undefined, or defined from star imports: skfem
tests/test_convergence.py:159:13: F405 'ElementTriP1' may be undefined, or defined from star imports: skfem
tests/test_convergence.py:160:16: F405 'InteriorBasis' may be undefined, or defined from star imports: skfem
tests/test_convergence.py:163:21: F405 'MeshTri' may be undefined, or defined from star imports: skfem
tests/test_convergence.py:172:13: F405 'ElementTriP2' may be undefined, or defined from star imports: skfem
tests/test_convergence.py:173:16: F405 'InteriorBasis' may be undefined, or defined from star imports: skfem
tests/test_convergence.py:179:13: F405 'ElementTriMini' may be undefined, or defined from star imports: skfem
tests/test_convergence.py:180:16: F405 'InteriorBasis' may be undefined, or defined from star imports: skfem
tests/test_convergence.py:189:13: F405 'ElementHex1' may be undefined, or defined from star imports: skfem
tests/test_convergence.py:190:16: F405 'InteriorBasis' may be undefined, or defined from star imports: skfem
tests/test_convergence.py:193:21: F405 'MeshHex' may be undefined, or defined from star imports: skfem
tests/test_convergence.py:203:13: F405 'ElementHexS2' may be undefined, or defined from star imports: skfem
tests/test_convergence.py:204:16: F405 'InteriorBasis' may be undefined, or defined from star imports: skfem
tests/test_convergence.py:207:21: F405 'MeshHex' may be undefined, or defined from star imports: skfem
tests/test_convergence.py:217:13: F405 'ElementTetP1' may be undefined, or defined from star imports: skfem
tests/test_convergence.py:218:16: F405 'InteriorBasis' may be undefined, or defined from star imports: skfem
tests/test_convergence.py:221:21: F405 'MeshTet' may be undefined, or defined from star imports: skfem
tests/test_convergence.py:231:13: F405 'ElementTetP2' may be undefined, or defined from star imports: skfem
tests/test_convergence.py:232:16: F405 'InteriorBasis' may be undefined, or defined from star imports: skfem
tests/test_convergence.py:235:21: F405 'MeshTet' may be undefined, or defined from star imports: skfem
tests/test_convergence.py:242:13: F405 'ElementTetMini' may be undefined, or defined from star imports: skfem
tests/test_convergence.py:243:16: F405 'InteriorBasis' may be undefined, or defined from star imports: skfem
tests/test_convergence.py:249:13: F405 'ElementLineP1' may be undefined, or defined from star imports: skfem
tests/test_convergence.py:250:16: F405 'InteriorBasis' may be undefined, or defined from star imports: skfem
tests/test_convergence.py:253:21: F405 'MeshLine' may be undefined, or defined from star imports: skfem
tests/test_convergence.py:262:13: F405 'ElementLineP2' may be undefined, or defined from star imports: skfem
tests/test_convergence.py:263:16: F405 'InteriorBasis' may be undefined, or defined from star imports: skfem
tests/test_convergence.py:266:21: F405 'MeshLine' may be undefined, or defined from star imports: skfem
tests/test_convergence.py:273:13: F405 'MeshTet' may be undefined, or defined from star imports: skfem
tests/test_convergence.py:273:22: F405 'ElementTetP2' may be undefined, or defined from star imports: skfem
tests/test_convergence.py:279:10: F405 'BilinearForm' may be undefined, or defined from star imports: skfem
tests/test_convergence.py:284:10: F405 'BilinearForm' may be undefined, or defined from star imports: skfem
tests/test_convergence.py:291:10: F405 'LinearForm' may be undefined, or defined from star imports: skfem
tests/test_convergence.py:308:10: F405 'LinearForm' may be undefined, or defined from star imports: skfem
tests/test_convergence.py:320:18: F405 'InteriorBasis' may be undefined, or defined from star imports: skfem
tests/test_convergence.py:321:18: F405 'FacetBasis' may be undefined, or defined from star imports: skfem
tests/test_convergence.py:323:17: F405 'asm' may be undefined, or defined from star imports: skfem
tests/test_convergence.py:324:17: F405 'asm' may be undefined, or defined from star imports: skfem
tests/test_convergence.py:326:17: F405 'asm' may be undefined, or defined from star imports: skfem
tests/test_convergence.py:327:17: F405 'asm' may be undefined, or defined from star imports: skfem
tests/test_convergence.py:329:17: F405 'solve' may be undefined, or defined from star imports: skfem
tests/test_convergence.py:376:13: F405 'MeshHex' may be undefined, or defined from star imports: skfem
tests/test_convergence.py:376:22: F405 'ElementHex1' may be undefined, or defined from star imports: skfem
tests/test_convergence.py:382:13: F405 'MeshHex' may be undefined, or defined from star imports: skfem
tests/test_convergence.py:382:22: F405 'ElementHexS2' may be undefined, or defined from star imports: skfem
tests/test_convergence.py:388:13: F405 'MeshTet' may be undefined, or defined from star imports: skfem
tests/test_convergence.py:388:22: F405 'ElementTetP1' may be undefined, or defined from star imports: skfem
```