### PR TITLE
Update tests/test_basis.py: fix flake8 errors

### DIFF
--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -3,7 +3,11 @@ from unittest import TestCase
 import numpy as np
 from numpy.testing import assert_allclose
 
-from skfem import *
+from skfem import BilinearForm, asm, solve, condense
+from skfem.mesh import MeshTri, MeshTet, MeshHex
+from skfem.assembly import InteriorBasis
+from skfem.element import (ElementVectorH1, ElementTriP2, ElementTriP1,
+                           ElementTetP2, ElementHexS2)
 
 
 class TestCompositeSplitting(TestCase):
@@ -29,7 +33,6 @@ class TestCompositeSplitting(TestCase):
         self.assertEqual(basis.find_dofs()['centreline'].all().size,
                          (2 + 1) * (2**(1 + 3) + 1) + 2 * 2**(1 + 3))
 
-        
         @BilinearForm
         def bilinf(u, p, v, q, w):
             from skfem.helpers import grad, ddot, div


### PR DESCRIPTION
```
tests/test_basis.py:6:1: F403 'from skfem import *' used; unable to detect undefined names
tests/test_basis.py:14:13: F405 'MeshTri' may be undefined, or defined from star imports: skfem
tests/test_basis.py:20:13: F405 'ElementVectorH1' may be undefined, or defined from star imports: skfem
tests/test_basis.py:20:29: F405 'ElementTriP2' may be undefined, or defined from star imports: skfem
tests/test_basis.py:20:47: F405 'ElementTriP1' may be undefined, or defined from star imports: skfem
tests/test_basis.py:25:17: F405 'InteriorBasis' may be undefined, or defined from star imports: skfem
tests/test_basis.py:32:1: W293 blank line contains whitespace
tests/test_basis.py:33:9: E303 too many blank lines (2)
tests/test_basis.py:33:10: F405 'BilinearForm' may be undefined, or defined from star imports: skfem
tests/test_basis.py:39:13: F405 'asm' may be undefined, or defined from star imports: skfem
tests/test_basis.py:45:13: F405 'solve' may be undefined, or defined from star imports: skfem
tests/test_basis.py:45:20: F405 'condense' may be undefined, or defined from star imports: skfem
tests/test_basis.py:62:17: F405 'MeshTet' may be undefined, or defined from star imports: skfem
tests/test_basis.py:63:17: F405 'ElementTetP2' may be undefined, or defined from star imports: skfem
tests/test_basis.py:70:17: F405 'InteriorBasis' may be undefined, or defined from star imports: skfem
tests/test_basis.py:87:17: F405 'MeshHex' may be undefined, or defined from star imports: skfem
tests/test_basis.py:88:17: F405 'ElementHexS2' may be undefined, or defined from star imports: skfem
```