### PR TITLE
Update tests/test_assembly.py: fix flake8 errors

### DIFF
--- a/tests/test_assembly.py
+++ b/tests/test_assembly.py
@@ -2,12 +2,19 @@ import unittest
 
 import numpy as np
 
-from skfem import *
+from skfem import (BilinearForm, LinearForm, Functional, asm, bilinear_form,
+                   linear_form, solve, functional)
+from skfem.element import (ElementQuad1, ElementQuadS2, ElementHex1,
+                           ElementHexS2, ElementTetP0, ElementTetP1,
+                           ElementTetP2, ElementTriP1, ElementQuad2,
+                           ElementTriMorley, ElementVectorH1)
+from skfem.mesh import MeshQuad, MeshHex, MeshTet, MeshTri
+from skfem.assembly import FacetBasis, InteriorBasis
 
 
 class IntegrateOneOverBoundaryQ1(unittest.TestCase):
     elem = ElementQuad1()
-    
+
     def createBasis(self):
         m = MeshQuad()
         m.refine(6)
@@ -48,7 +55,7 @@ class IntegrateOneOverBoundaryHex1(IntegrateOneOverBoundaryQ1):
         self.boundary_area = 6.000
 
 
-class IntegrateOneOverBoundaryHex1(IntegrateOneOverBoundaryQ1):
+class IntegrateOneOverBoundaryHex1_2(IntegrateOneOverBoundaryQ1):
 
     def createBasis(self):
         m = MeshHex()
@@ -134,8 +141,8 @@ class BasisInterpolator(unittest.TestCase):
         x = self.initOnes(ib)
         f = ib.interpolator(x)
 
-        self.assertTrue(np.sum(f(np.array([np.sin(m.p[0, :]),
-                                           np.sin(3. * m.p[1, :])])) - 1.) < 1e-10)
+        X = np.array([np.sin(m.p[0, :]), np.sin(3. * m.p[1, :])])
+        self.assertTrue(np.sum(f(X) - 1.0) < 1.0e-10)
 
 
 class BasisInterpolatorTriP2(BasisInterpolator):
@@ -308,7 +315,7 @@ class TestFieldInterpolation(unittest.TestCase):
         self.assertAlmostEqual(feqx.assemble(basis, func=func), 1.)
 
 
-class TestFieldInterpolation(unittest.TestCase):
+class TestFieldInterpolation_2(unittest.TestCase):
 
     def runTest(self):
 


### PR DESCRIPTION
```
tests/test_assembly.py:5:1: F403 'from skfem import *' used; unable to detect undefined names
tests/test_assembly.py:9:12: F405 'ElementQuad1' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:10:1: W293 blank line contains whitespace
tests/test_assembly.py:12:13: F405 'MeshQuad' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:14:23: F405 'FacetBasis' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:20:10: F405 'BilinearForm' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:24:13: F405 'asm' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:26:10: F405 'LinearForm' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:30:13: F405 'asm' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:39:12: F405 'ElementQuadS2' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:45:13: F405 'MeshHex' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:47:23: F405 'FacetBasis' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:47:37: F405 'ElementHex1' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:51:1: F811 redefinition of unused 'IntegrateOneOverBoundaryHex1' from line 42
tests/test_assembly.py:54:13: F405 'MeshHex' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:56:23: F405 'FacetBasis' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:56:37: F405 'ElementHexS2' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:63:19: F405 'MeshHex' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:63:28: F405 'ElementHex1' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:64:19: F405 'MeshTet' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:64:28: F405 'ElementTetP1' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:65:19: F405 'MeshTet' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:65:28: F405 'ElementTetP0' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:70:18: F405 'FacetBasis' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:72:14: F405 'BilinearForm' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:77:17: F405 'asm' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:85:13: F405 'MeshHex' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:85:22: F405 'ElementHex1' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:92:14: F405 'FacetBasis' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:94:10: F405 'BilinearForm' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:99:13: F405 'asm' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:106:13: F405 'MeshHex' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:106:22: F405 'ElementHexS2' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:110:13: F405 'MeshTet' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:110:22: F405 'ElementTetP1' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:114:13: F405 'MeshTet' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:114:22: F405 'ElementTetP2' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:118:13: F405 'MeshTet' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:118:22: F405 'ElementTetP0' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:122:13: F405 'MeshTri' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:122:22: F405 'ElementTriP1' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:132:14: F405 'InteriorBasis' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:138:80: E501 line too long (83 > 79 characters)
tests/test_assembly.py:142:13: F405 'MeshQuad' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:142:23: F405 'ElementQuad1' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:146:13: F405 'MeshQuad' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:146:23: F405 'ElementQuad1' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:150:13: F405 'MeshQuad' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:150:23: F405 'ElementQuad2' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:154:13: F405 'MeshQuad' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:154:23: F405 'ElementQuadS2' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:158:13: F405 'MeshTri' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:158:22: F405 'ElementTriMorley' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:161:10: F405 'bilinear_form' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:165:10: F405 'linear_form' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:169:13: F405 'asm' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:170:13: F405 'asm' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:172:16: F405 'solve' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:176:13: F405 'MeshTri' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:176:24: F405 'ElementTriP1' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:184:21: F405 'FacetBasis' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:186:21: F405 'FacetBasis' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:188:10: F405 'linear_form' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:192:13: F405 'asm' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:201:18: F405 'linear_form' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:205:21: F405 'asm' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:210:13: F405 'MeshTet' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:210:24: F405 'ElementTetP1' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:214:13: F405 'MeshTet' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:214:24: F405 'ElementTetP2' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:219:13: F405 'MeshQuad' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:219:25: F405 'ElementQuad1' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:223:13: F405 'MeshHex' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:223:24: F405 'ElementHex1' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:228:13: F405 'MeshHex' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:228:24: F405 'ElementHexS2' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:236:13: F405 'MeshQuad' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:238:13: F405 'ElementQuad1' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:239:17: F405 'InteriorBasis' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:241:10: F405 'functional' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:245:13: F405 'asm' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:255:13: F405 'MeshQuad' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:257:13: F405 'ElementQuad1' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:258:17: F405 'InteriorBasis' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:269:13: F405 'MeshHex' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:271:14: F405 'ElementHex1' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:271:30: F405 'ElementHex1' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:271:46: F405 'ElementHex1' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:272:14: F405 'ElementVectorH1' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:272:30: F405 'ElementHex1' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:273:18: F405 'InteriorBasis' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:274:18: F405 'InteriorBasis' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:276:10: F405 'BilinearForm' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:281:10: F405 'BilinearForm' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:285:14: F405 'asm' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:286:14: F405 'asm' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:295:13: F405 'MeshTri' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:296:13: F405 'ElementTriP1' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:297:17: F405 'InteriorBasis' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:299:10: F405 'Functional' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:311:1: F811 redefinition of unused 'TestFieldInterpolation' from line 291
tests/test_assembly.py:315:13: F405 'MeshTri' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:316:13: F405 'ElementTriP1' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:317:17: F405 'InteriorBasis' may be undefined, or defined from star imports: skfem
tests/test_assembly.py:319:10: F405 'Functional' may be undefined, or defined from star imports: skfem
```