### PR TITLE
pin at pacopy 0.1.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
   - conda info -a
   - conda create -q -n scikit-fem python=$TRAVIS_PYTHON_VERSION nomkl numpy scipy matplotlib ipython pip
   - source activate scikit-fem
-  - pip install meshio dmsh pacopy pygmsh pyamg flake8
+  - pip install meshio dmsh pacopy==0.1.2 pygmsh pyamg flake8
 script:
   - flake8 skfem || travis_terminate 1;
   - python -m unittest discover

--- a/docs/examples/ex10.py
+++ b/docs/examples/ex10.py
@@ -30,7 +30,7 @@ x = np.zeros(basis.N)
 
 I = m.interior_nodes()
 D = m.boundary_nodes()
-x[D] = np.sin(np.pi * m.p[0, D]) 
+x[D] = np.sin(np.pi * m.p[0, D])
 
 for itr in range(100):
     w = basis.interpolate(x)

--- a/docs/examples/ex23.py
+++ b/docs/examples/ex23.py
@@ -2,9 +2,9 @@ r"""Bratu–Gelfand.
 
 .. note::
 
-   This example requires the external package `pacopy <https://github.com/nschloe/pacopy>`_
+   This example requires the external package `pacopy 0.1.2 <https://pypi.org/project/pacopy/0.1.2/>`_
 
-Here the bifurcation diagram for the Bratu–Gelfand two-point boundary value problem is reproduced by numerical continuation as implemented in pacopy, and adapted from the pacopy example `Bratu <https://github.com/nschloe/pacopy/blob/master/README.md#bratu>`_.
+Here the bifurcation diagram for the Bratu–Gelfand two-point boundary value problem is reproduced by numerical continuation as implemented in pacopy, and adapted from the pacopy example `Bratu <https://github.com/nschloe/pacopy/blob/v0.1.2/README.md#bratu>`_.
 
 .. math::
     u'' + \lambda \mathrm e^u = 0, \quad 0 < x < 1,

--- a/docs/examples/ex23.py
+++ b/docs/examples/ex23.py
@@ -16,7 +16,7 @@ For treatment by numerical continuation, we define the residual
     F(u, \lambda) = -u'' - \lambda \mathrm e^u
 .. literalinclude:: ex23.py
     :start-at: def f
-    :lines: 1-5	       
+    :lines: 1-5
 
 its derivative with respect to the parameter
 
@@ -24,7 +24,7 @@ its derivative with respect to the parameter
    \frac{\partial F}{\partial\lambda} = -\mathrm e^u
 .. literalinclude:: ex23.py
     :start-at: def df_dlmbda
-    :lines: 1-8	       
+    :lines: 1-8
 
 and the Jacobian
 
@@ -32,7 +32,7 @@ and the Jacobian
    J (u) = -\frac{\mathrm d^2}{\mathrm dx^2} - \lambda \mathrm e^u
 .. literalinclude:: ex23.py
     :start-at: def jacobian_solver
-    :lines: 1-11	       
+    :lines: 1-11
 
 The resulting bifurcation diagram, matches figure 1.1 (left) of Farrell, Birkisson, & Funke (2015).
 

--- a/docs/examples/ex23.py
+++ b/docs/examples/ex23.py
@@ -4,7 +4,7 @@ r"""Bratu–Gelfand.
 
    This example requires the external package `pacopy 0.1.2 <https://pypi.org/project/pacopy/0.1.2/>`_
 
-Here the bifurcation diagram for the Bratu–Gelfand two-point boundary value problem is reproduced by numerical continuation as implemented in pacopy, and adapted from the pacopy example `Bratu <https://github.com/nschloe/pacopy/blob/v0.1.2/README.md#bratu>`_.
+Here the bifurcation diagram for the Bratu–Gelfand two-point boundary value problem is reproduced by numerical continuation as implemented in pacopy 0.1.2, and adapted from the pacopy 0.1.2 example `Bratu <https://github.com/nschloe/pacopy/blob/v0.1.2/README.md#bratu>`_.
 
 .. math::
     u'' + \lambda \mathrm e^u = 0, \quad 0 < x < 1,

--- a/docs/examples/ex27.py
+++ b/docs/examples/ex27.py
@@ -1,10 +1,10 @@
 r"""Backward-facing step.
 
 .. warning::
-   This example requires the external packages `pygmsh <https://pypi.org/project/pygmsh/>`_ and `pacopy <https://pypi.org/project/pacopy/>`_.
+   This example requires the external packages `pygmsh <https://pypi.org/project/pygmsh/>`_ and `pacopy 0.1.2 <https://pypi.org/project/pacopy/0.1.2/>`_.
 
 
-In this example, `pacopy <https://pypi.org/project/pacopy/>`_ is used to extend
+In this example, `pacopy 0.1.2 <https://pypi.org/project/pacopy/0.1.2/>`_ is used to extend
 the Stokes equations over a backward-facing step to finite Reynolds
 number; this means defining a residual for the nonlinear problem and its
 derivatives with respect to the solution and to the parameter (here Reynolds

--- a/docs/listofexamples.rst
+++ b/docs/listofexamples.rst
@@ -320,7 +320,7 @@ This example solves the Bratu-Gelfand two-point boundary value problem :math:`u'
 with :math:`u(0)=u(1)=0` and where :math:`\lambda > 0` is a parameter.
 
 .. note::
-   This example requires the external package `pacopy <https://github.com/nschloe/pacopy>`__.
+   This example requires the external package `pacopy 0.1.2 <https://pypi.org/project/pacopy/0.1.2>`__.
 
 .. figure:: https://user-images.githubusercontent.com/973268/87779278-38ccf700-c835-11ea-955a-b77a0336b791.png
 
@@ -375,13 +375,13 @@ See the `source code of Example 26 <https://github.com/kinnala/scikit-fem/blob/m
 Example 27: Backward-facing step
 ================================
 
-This example uses `pacopy <https://pypi.org/project/pacopy/>`__ to extend
+This example uses `pacopy 0.1.2 <https://pypi.org/project/pacopy/0.1.2>`__ to extend
 the Stokes equations over a backward-facing step (Example 24) to finite Reynolds
 number; this means defining a residual for the nonlinear problem and its
 derivatives with respect to the solution and to the Reynolds number.
 
 .. note::
-   This example requires the external packages `pygmsh <https://pypi.org/project/pygmsh/>`___ and `pacopy <https://pypi.org/project/pacopy/>`__.
+   This example requires the external packages `pygmsh <https://pypi.org/project/pygmsh/>`___ and `pacopy 0.1.2 <https://pypi.org/project/pacopy/0.1.2>`__.
 
 .. figure:: https://user-images.githubusercontent.com/973268/87858972-97c86400-c93a-11ea-86e4-66f870b03e48.png
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ sphinx
 meshio
 dmsh
 pygmsh
-pacopy
+pacopy==0.1.2
 sphinx_rtd_theme


### PR DESCRIPTION
Fixes #451.

This is a quick interim measure, avoiding having to specially license exx 23, 27; later I envisage writing a fresh natural parameter continuation function that is compatible with the use of `functools.partial(scipy.optimize.root(method="krylov")` as nonlinear solver #119. 

ex23 is not particularly important; it could be dropped if it came to it.  It was primarily developed as a first step in using scikit-fem with pacopy.

ex27 however is very important.  It's the first example solving the Navier&ndash;Stokes equation.  It contains much that is original that should be reused and expanded in subsequent examples.  It should not be brought under GPLv3+.

This PR specifies all references to pacopy as being to pacopy 0.1.2, https://pypi.org/project/pacopy/0.1.2/, except for those in the paper

https://github.com/kinnala/scikit-fem/blob/80a4f7d38f7aa3a9972969110ae5e9b8e6672efd/paper/paper.md#L48

https://github.com/kinnala/scikit-fem/blob/80a4f7d38f7aa3a9972969110ae5e9b8e6672efd/paper/paper.bib#L111-L116
