### PR TITLE
demonstrate integration with PyMumps

### DIFF
--- a/docs/integrations/solver_pymumps.py
+++ b/docs/integrations/solver_pymumps.py
@@ -1,0 +1,41 @@
+from skfem import *
+from skfem.models.poisson import *
+from skfem.utils import LinearSolver
+import numpy as np
+from scipy.sparse import spmatrix
+from scipy.sparse.linalg import LinearOperator
+from mumps import DMumpsContext
+
+
+def solver_mumps() -> LinearSolver:
+    # as per https://github.com/pymumps/pypumps README.md
+    def solver(A: spmatrix, b: np.ndarray) -> np.ndarray:
+        ctx = DMumpsContext()
+        if ctx.myid == 0:
+            ctx.set_centralized_sparse(A)
+            x = b.copy()
+            ctx.set_rhs(x)
+        ctx.run(job=6)
+        ctx.destroy()
+        return x
+
+    return solver
+
+
+p = np.linspace(0, 1, 16)
+m = MeshTet.init_tensor(*(p,) * 3)
+
+e = ElementTetP1()
+basis = InteriorBasis(m, e)
+
+A = asm(laplace, basis)
+b = asm(unit_load, basis)
+
+I = m.interior_nodes()
+
+x = solve(*condense(A, b, I=I))
+
+if __name__ == "__main__":
+    from pathlib import Path
+
+    m.save(Path(__file__).with_suffix(".xdmf"), {"potential": x})

--- a/docs/integrations/solver_pymumps.py
+++ b/docs/integrations/solver_pymumps.py
@@ -33,7 +33,7 @@ b = asm(unit_load, basis)
 
 I = m.interior_nodes()
 
-x = solve(*condense(A, b, I=I))
+x = solve(*condense(A, b, I=I), solver=solver_mumps())
 
 if __name__ == "__main__":
     from pathlib import Path

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -1,0 +1,10 @@
+import numpy as np
+
+import pytest
+
+pytest.importorskip("mumps")
+
+
+def test_pymumps():
+    import docs.integrations.solver_pymumps as example
+    np.testing.assert_almost_equal(np.linalg.norm(example.x, np.inf), 0.05528520791811886)


### PR DESCRIPTION
A first step in demonstrating integrations #474.  

This redoes the MeshTet Poisson Dirichlet problem of ex09 (currently in mind because of the regression involving `solver_iter_pcg`, `build_pc_ilu`, and `MeshTet.init_tensor` #469) using a parallel direct solver from PyMumps.
