### PR TITLE
DOC: delete obsolete references to pygmsh

### DIFF
--- a/docs/examples/ex13.py
+++ b/docs/examples/ex13.py
@@ -2,16 +2,14 @@ r"""Laplace with mixed boundary conditions.
 
 This example is another extension of `ex01.py`, still solving the Laplace
 equation but now with mixed boundary conditions, two parts isopotential (charged
-and earthed) and the rest insulated. The isopotential parts are tagged during
-the construction of the geometry in `pygmsh
-<https://pypi.org/project/pygmsh/>`_.
+and earthed) and the rest insulated.
 
 The example is :math:`\Delta u = 0` in
 :math:`\Omega=\{(x,y):1<x^2+y^2<4,~0<\theta<\pi/2\}`, where :math:`\tan \theta =
 y/x`, with :math:`u = 0` on :math:`y = 0` and :math:`u = 1` on :math:`x =
-0`. Although these boundaries would be simple enough to identify using the
-coordinates and :meth:`skfem.assembly.Basis.find_dofs`, the present
-technique generalizes to more complicated shapes.
+0`.  The mesh is first constructed as a rectangle in the :math:`r\theta`-plane,
+where the isopotential parts are conveniently tagged using `skfem.Mesh.define_boundary`;
+then the mesh is mapped to the :math:`xy`-plane.
 
 The exact solution is :math:`u = 2 \theta / \pi`. The field strength is :math:`|\nabla u|^2 = 4 / \pi^2 (x^2 + y^2)`
 so the conductance (for unit potential difference and conductivity) is

--- a/docs/listofexamples.rst
+++ b/docs/listofexamples.rst
@@ -53,10 +53,6 @@ between two elastic bodies using the Nitsche's method.
 Triangular and quadrilateral second-order elements are used
 in the discretization of the two elastic bodies.
 
-.. note::
-
-   This example requires the external package `pygmsh <https://pypi.org/project/pygmsh/>`__.
-
 .. figure:: https://user-images.githubusercontent.com/973268/87661313-1372b700-c769-11ea-89ee-db144986a25a.png
 
    The displaced meshes and the von Mises stress of Example 4.

--- a/docs/listofexamples.rst
+++ b/docs/listofexamples.rst
@@ -492,10 +492,6 @@ This example solves the series inductance (per meter) and parallel capacitance
 (per meter) of RG316 coaxial cable. These values are then used to compute the
 characteristic impedance and velocity factor of the cable.
 
-.. note::
-   This example requires the external package
-   `pygmsh <https://pypi.org/project/pygmsh/>`__.
-
 .. figure:: https://user-images.githubusercontent.com/973268/87859275-85e7c080-c93c-11ea-9e62-3a9a8ee86070.png
 
    The results of Example 35.


### PR DESCRIPTION
The documentation for a couple of the examples still refers to pygmsh even though they've dropped it.