### PR TITLE
skfem.models.general.vrot as adjoint of rot

### DIFF
--- a/docs/examples/ex20.py
+++ b/docs/examples/ex20.py
@@ -52,30 +52,29 @@ stokes = asm(biharmonic, ib)
 rotf = asm(unit_load, ib)
 
 psi = solve(*condense(stokes, rotf, D=ib.find_dofs()))
-psi0, = ib.interpolator(psi)(np.zeros((2, 1)))
+(psi0,) = ib.interpolator(psi)(np.zeros((2, 1)))
 
 if __name__ == "__main__":
     from os.path import splitext
     from sys import argv
+    from skfem.models.general import vrot
     from skfem.visuals.matplotlib import draw
     from matplotlib.tri import Triangulation
 
-    print('psi0 = {} (cf. exact = 1/64 = {})'.format(psi0, 1/64))
+    print("psi0 = {} (cf. exact = 1/64 = {})".format(psi0, 1 / 64))
 
     M, Psi = ib.refinterp(psi, 3)
 
     ax = draw(mesh)
     ax.tricontour(Triangulation(*M.p, M.t.T), Psi)
     name = splitext(argv[0])[0]
-    ax.get_figure().savefig(f'{name}_stream-lines.png')
+    ax.get_figure().savefig(f"{name}_stream-lines.png")
 
-    refbasis = InteriorBasis(M, ElementTriP1())
-    velocity = np.vstack([derivative(Psi, refbasis, refbasis, 1),
-                          -derivative(Psi, refbasis, refbasis, 0)])
+    velocity = asm(
+        vrot,
+        InteriorBasis(mesh, ElementVectorH1(ElementTriP1()), quadrature=ib.quadrature),
+        w=ib.interpolate(psi),
+    )
     ax = draw(mesh)
-    sparsity_factor = 2**3      # subsample the arrows
-    vector_factor = 2**3        # lengthen the arrows
-    x = M.p[:, ::sparsity_factor]
-    u = vector_factor * velocity[:, ::sparsity_factor]
-    ax.quiver(*x, *u, x[0])
-    ax.get_figure().savefig(f'{name}_velocity-vectors.png')
+    ax.quiver(*mesh.p, *velocity, mesh.p[0])
+    ax.get_figure().savefig(f"{name}_velocity-vectors.png")

--- a/docs/examples/ex20.py
+++ b/docs/examples/ex20.py
@@ -74,5 +74,5 @@ if __name__ == "__main__":
         w=ib.interpolate(psi),
     )
     ax = draw(mesh)
-    ax.quiver(*mesh.p, *velocity, mesh.p[0])
+    ax.quiver(*mesh.p, *velocity.reshape((-1, 2)).T, mesh.p[0])
     ax.get_figure().savefig(f"{name}_velocity-vectors.png")

--- a/docs/examples/ex20.py
+++ b/docs/examples/ex20.py
@@ -26,10 +26,8 @@ polynomial solution with circular stream-lines:
     \psi = \left(1 - (x^2+y^2)/a^2\right)^2 / 64.
 
 """
-from pathlib import Path
 
 from skfem import *
-from skfem.io.json import from_file
 from skfem.models.poisson import unit_load
 
 import numpy as np

--- a/skfem/models/general.py
+++ b/skfem/models/general.py
@@ -15,3 +15,9 @@ def divergence(u, v, w):
 def rot(v, w):
     return np.einsum('i...,ij...,j...',
                      w.w, np.array([[0, 1], [-1, 0]]), grad(v))
+
+
+@LinearForm
+def vrot(v, w):
+    return np.einsum('i...,ij...,j...',
+                     v, np.array([[0, 1], [-1, 0]]), grad(w['w']))

--- a/skfem/models/general.py
+++ b/skfem/models/general.py
@@ -1,9 +1,7 @@
 """Bilinear and linear forms too general to put into a specific model."""
 
 from skfem.assembly import BilinearForm, LinearForm
-from .helpers import div, grad
-
-import numpy as np
+from .helpers import dot, div, curl
 
 
 @BilinearForm
@@ -13,11 +11,9 @@ def divergence(u, v, w):
 
 @LinearForm
 def rot(v, w):
-    return np.einsum('i...,ij...,j...',
-                     w.w, np.array([[0, 1], [-1, 0]]), grad(v))
+    return dot(curl(v), w.w)
 
 
 @LinearForm
 def vrot(v, w):
-    return np.einsum('i...,ij...,j...',
-                     v, np.array([[0, 1], [-1, 0]]), grad(w['w']))
+    return dot(v, curl(w.w))


### PR DESCRIPTION
Inspired by the discussion in #505, I defined `skfem.models.general: LinearForm`, being the adjoint (is that the right word) of `skfem.model.general.rot` in the sense that (**u**, **vrot** _&psi;_) = (rot **u**, _&psi;_), where everything is two-dimensional and _&psi;_ and **u** are scalar and vector fields, respectively.

This is used to simplify the calculation of the velocity from the stream-function in ex20, where the stream-function is defined using `ElementTriMorley`, as in the question #505 (though the actual question was about a *bi*-linear form).

I'm not at all sure about the name!  Sometimes I've seen this pair distinguished by bold and roman type (rot **u** is a scalar, the vorticity; **rot** _&psi;_ is a vector, the velocity, and rot **rot** _&psi;_ = &minus;&Delta; _&psi;_); here the bold one gets a v for vector at the front, but alternative suggestions are welcome.