### PR TITLE
Redundant preallocation

### DIFF
--- a/docs/examples/ex22.py
+++ b/docs/examples/ex22.py
@@ -74,7 +74,6 @@ for itr in range(10): # 10 adaptive refinements
     
     K = asm(laplace, basis)
     f = asm(load, basis)
-    u = np.zeros_like(f)
     
     I = m.interior_nodes()
     u = solve(*condense(K, f, I=I))

--- a/docs/examples/ex22.py
+++ b/docs/examples/ex22.py
@@ -66,7 +66,7 @@ if __name__ == "__main__":
     from skfem.visuals.matplotlib import draw, plot, show
     draw(m)
 
-for itr in range(10): # 10 adaptive refinements
+for itr in range(9): # 9 adaptive refinements
     if itr > 0:
         m.refine(adaptive_theta(eval_estimator(m, u)))
         

--- a/docs/examples/ex22.py
+++ b/docs/examples/ex22.py
@@ -67,7 +67,7 @@ if __name__ == "__main__":
     draw(m)
 
 for itr in range(10): # 10 adaptive refinements
-    if itr > 1:
+    if itr > 0:
         m.refine(adaptive_theta(eval_estimator(m, u)))
         
     basis = InteriorBasis(m, e)


### PR DESCRIPTION
A couple of minor fixes in ex22.
* First I noticed that *u* was set to zero before the `solve`, but this hasn't been necessary since #228.
* Then I noticed that the first two meshes were the same; perhaps instead of `itr > 1`, `>= 1` was intended, or `> 0`, as suggested here.