### PR TITLE
refine -> refined in uncontentious cases 

### DIFF
--- a/docs/examples/ex01.py
+++ b/docs/examples/ex01.py
@@ -1,8 +1,7 @@
 from skfem import *
 from skfem.models.poisson import laplace, unit_load
 
-m = MeshTri()
-m.refine(4)
+m = MeshTri().refined(4)
 
 e = ElementTriP1()
 basis = InteriorBasis(m, e)

--- a/docs/examples/ex02.py
+++ b/docs/examples/ex02.py
@@ -69,8 +69,7 @@ from skfem import *
 from skfem.models.poisson import unit_load
 import numpy as np
 
-m = MeshTri.init_symmetric()
-m.refine(3)
+m = MeshTri.init_symmetric().refined(3)
 
 e = ElementTriMorley()
 ib = InteriorBasis(m, e)

--- a/docs/examples/ex04.py
+++ b/docs/examples/ex04.py
@@ -65,10 +65,11 @@ from pathlib import Path
 mesh_file = Path(__file__).parent / 'meshes' / 'ex04_mesh.json'
 m = from_file(mesh_file)
 
-M = MeshLine(np.linspace(0, 1, 6)) * MeshLine(np.linspace(-1, 1, 10))
-M.translate((1.0, 0.0))
-M.refine()
-
+M = (
+    (MeshLine(np.linspace(0, 1, 6)) * MeshLine(np.linspace(-1, 1, 10)))
+    .translated((1.0, 0.0))
+    .refined()
+)
 
 # define elements and bases
 e1 = ElementTriP2()

--- a/docs/examples/ex05.py
+++ b/docs/examples/ex05.py
@@ -20,8 +20,7 @@ from skfem import *
 from skfem.helpers import dot, grad
 from skfem.models.poisson import laplace
 
-m = MeshTri()
-m.refine(5)
+m = MeshTri().refined(5)
 
 e = ElementTriP1()
 

--- a/docs/examples/ex06.py
+++ b/docs/examples/ex06.py
@@ -29,8 +29,7 @@ elements are defined using an isoparametric local-to-global mapping.
 from skfem import *
 from skfem.models.poisson import laplace, unit_load
 
-m = MeshQuad()
-m.refine(2)
+m = MeshQuad().refined(2)
 
 e1 = ElementQuad1()
 e = ElementQuad2()

--- a/docs/examples/ex07.py
+++ b/docs/examples/ex07.py
@@ -4,8 +4,7 @@ from skfem import *
 from skfem.helpers import grad, dot
 from skfem.models.poisson import laplace, unit_load
 
-m = MeshTri.init_sqsymmetric()
-m.refine()
+m = MeshTri.init_sqsymmetric().refined()
 mapping = MappingAffine(m)
 e = ElementTriDG(ElementTriP1())
 alpha = 1e-1

--- a/docs/examples/ex10.py
+++ b/docs/examples/ex10.py
@@ -8,8 +8,7 @@ from skfem import *
 from skfem.helpers import grad, dot
 import numpy as np
 
-m = MeshTri()
-m.refine(5)
+m = MeshTri().refined(5)
 
 
 @BilinearForm

--- a/docs/examples/ex11.py
+++ b/docs/examples/ex11.py
@@ -10,8 +10,7 @@ import numpy as np
 from skfem import *
 from skfem.models.elasticity import linear_elasticity, lame_parameters
 
-m = MeshHex()
-m.refine(3)
+m = MeshHex().refined(3)
 e1 = ElementHex1()
 e = ElementVectorH1(e1)
 ib = InteriorBasis(m, e, MappingIsoparametric(m, e1), 3)

--- a/docs/examples/ex14.py
+++ b/docs/examples/ex14.py
@@ -25,8 +25,7 @@ from skfem.models.poisson import laplace
 
 import numpy as np
 
-m = MeshTri()
-m.refine(4)
+m = MeshTri().refined(4)
 
 e = ElementTriP2()
 basis = InteriorBasis(m, e)

--- a/docs/examples/ex22.py
+++ b/docs/examples/ex22.py
@@ -17,8 +17,7 @@ from skfem.models.poisson import laplace
 from skfem.helpers import grad
 import numpy as np
 
-m = MeshTri.init_lshaped()
-m.refine(2)
+m = MeshTri.init_lshaped().refined(2)
 e = ElementTriP1()
 
 def load_func(x, y):
@@ -68,7 +67,7 @@ if __name__ == "__main__":
 
 for itr in range(9): # 9 adaptive refinements
     if itr > 0:
-        m.refine(adaptive_theta(eval_estimator(m, u)))
+        m = m.refined(adaptive_theta(eval_estimator(m, u)))
         
     basis = InteriorBasis(m, e)
     

--- a/docs/examples/ex34.py
+++ b/docs/examples/ex34.py
@@ -11,8 +11,7 @@ The analytical solution gives :math:`u(1)=1/8`.
 """
 from skfem import *
 
-m = MeshLine()
-m.refine(3)
+m = MeshLine().refined(3)
 e = ElementLineHermite()
 basis = InteriorBasis(m, e)
 

--- a/docs/examples/ex36.py
+++ b/docs/examples/ex36.py
@@ -149,8 +149,7 @@ def A22(w):
     return L
 
 
-mesh = MeshTet()
-mesh.refine(2)
+mesh = MeshTet().refined(2)
 uelem = ElementVectorH1(ElementTetP2())
 pelem = ElementTetP1()
 elems = {

--- a/skfem/assembly/basis/interior_basis.py
+++ b/skfem/assembly/basis/interior_basis.py
@@ -100,8 +100,7 @@ class InteriorBasis(Basis):
         """Refine and interpolate (for plotting)."""
         # mesh reference domain, refine and take the vertices
         meshclass = type(self.mesh)
-        m = meshclass.init_refdom()
-        m.refine(Nrefs)
+        m = meshclass.init_refdom().refined(Nrefs)
         X = m.p
 
         # map vertices to global elements

--- a/skfem/mesh/mesh2d/mesh_tri.py
+++ b/skfem/mesh/mesh2d/mesh_tri.py
@@ -287,7 +287,7 @@ class MeshTri(Mesh2D):
                       [0, 3, 4]], dtype=np.intp).T
         m = cls(p, t)
         for _ in range(Nrefs):
-            m.refine()
+            m = m.refined()
             D = m.boundary_nodes()
             m.p[:, D] = m.p[:, D] / np.linalg.norm(m.p[:, D], axis=0)
         return m

--- a/skfem/mesh/mesh3d/mesh_tet.py
+++ b/skfem/mesh/mesh3d/mesh_tet.py
@@ -201,7 +201,7 @@ class MeshTet(Mesh3D):
                       [0, 5, 6, 1]], dtype=np.intp).T
         m = cls(p, t)
         for _ in range(Nrefs):
-            m.refine()
+            m = m.refined()
             D = m.boundary_nodes()
             m.p[:, D] = m.p[:, D] / np.linalg.norm(m.p[:, D], axis=0)
         return m

--- a/tests/test_assembly.py
+++ b/tests/test_assembly.py
@@ -208,19 +208,18 @@ class NormalVectorTestTri(unittest.TestCase):
     intorder = None
 
     def runTest(self):
-        self.case[0].refine()
+        m = self.case[0].refined()
 
         if self.intorder is not None:
-            basis = FacetBasis(*self.case, intorder=self.intorder)
+            basis = FacetBasis(m, self.case[1], intorder=self.intorder)
         else:
-            basis = FacetBasis(*self.case)
+            basis = FacetBasis(m, self.case[1])
 
         @LinearForm
         def linf(v, w):
             return np.sum(w.n ** 2, axis=0) * v
 
         b = asm(linf, basis)
-        m = self.case[0]
         ones = project(lambda x: 1.0 + x[0] * 0.,
                        basis_to=basis,
                        I=basis.get_dofs().flatten(),

--- a/tests/test_assembly.py
+++ b/tests/test_assembly.py
@@ -18,8 +18,7 @@ class IntegrateOneOverBoundaryQ1(unittest.TestCase):
     elem = ElementQuad1()
 
     def createBasis(self):
-        m = MeshQuad()
-        m.refine(6)
+        m = MeshQuad().refined(6)
         self.fbasis = FacetBasis(m, self.elem)
         self.boundary_area = 4.0000
 
@@ -52,8 +51,7 @@ class IntegrateOneOverBoundaryS2(IntegrateOneOverBoundaryQ1):
 class IntegrateOneOverBoundaryHex1(IntegrateOneOverBoundaryQ1):
 
     def createBasis(self):
-        m = MeshHex()
-        m.refine(3)
+        m = MeshHex().refined(3)
         self.fbasis = FacetBasis(m, ElementHex1())
         self.boundary_area = 6.000
 
@@ -61,8 +59,7 @@ class IntegrateOneOverBoundaryHex1(IntegrateOneOverBoundaryQ1):
 class IntegrateOneOverBoundaryHex1_2(IntegrateOneOverBoundaryQ1):
 
     def createBasis(self):
-        m = MeshHex()
-        m.refine(3)
+        m = MeshHex().refined(3)
         self.fbasis = FacetBasis(m, ElementHexS2())
         self.boundary_area = 6.000
 
@@ -70,8 +67,7 @@ class IntegrateOneOverBoundaryHex1_2(IntegrateOneOverBoundaryQ1):
 class IntegrateOneOverBoundaryHex2(IntegrateOneOverBoundaryQ1):
 
     def createBasis(self):
-        m = MeshHex()
-        m.refine(3)
+        m = MeshHex().refined(3)
         self.fbasis = FacetBasis(m, ElementHex2())
         self.boundary_area = 6.000
 
@@ -84,8 +80,7 @@ class IntegrateFuncOverBoundary(unittest.TestCase):
                  (MeshTet, ElementTetP0)]
 
         for (mtype, etype) in cases:
-            m = mtype()
-            m.refine(3)
+            m = mtype().refined(3)
             fb = FacetBasis(m, etype())
 
             @BilinearForm
@@ -106,8 +101,7 @@ class IntegrateFuncOverBoundaryPart(unittest.TestCase):
 
     def runTest(self):
         mtype, etype = self.case
-        m = mtype()
-        m.refine(3)
+        m = mtype().refined(3)
         bnd = m.facets_satisfying(lambda x: x[0] == 1.0)
         fb = FacetBasis(m, etype(), facets=bnd)
 
@@ -156,8 +150,7 @@ class BasisInterpolator(unittest.TestCase):
 
     def runTest(self):
         mtype, etype = self.case
-        m = mtype()
-        m.refine(3)
+        m = mtype().refined(3)
         e = etype()
         ib = InteriorBasis(m, e)
 
@@ -293,8 +286,7 @@ class NormalVectorTestHex2(NormalVectorTestTri):
 class EvaluateFunctional(unittest.TestCase):
 
     def runTest(self):
-        m = MeshQuad()
-        m.refine(3)
+        m = MeshQuad().refined(3)
         e = ElementQuad1()
         basis = InteriorBasis(m, e)
 
@@ -312,8 +304,7 @@ class EvaluateFunctional(unittest.TestCase):
 class TestRefinterp(unittest.TestCase):
 
     def runTest(self):
-        m = MeshQuad()
-        m.refine(2)
+        m = MeshQuad().refined(2)
         e = ElementQuad1()
         basis = InteriorBasis(m, e)
 

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -20,11 +20,10 @@ class TestCompositeSplitting(TestCase):
     def runTest(self):
         """Solve Stokes problem, try splitting and other small things."""
 
-        m = MeshTri()
-        m.refine()
+        m = MeshTri().refined()
         m.define_boundary('centreline', lambda x: x[0] == .5,
                           boundaries_only=False)
-        m.refine(3)
+        m = m.refined(3)
 
         e = ElementVectorH1(ElementTriP2()) * ElementTriP1()
 
@@ -99,8 +98,7 @@ class TestFacetExpansion(TestCase):
 
     def runTest(self):
 
-        m = self.mesh_type()
-        m.refine(2)
+        m = self.mesh_type().refined(2)
 
         basis = InteriorBasis(m, self.elem_type())
 
@@ -136,8 +134,7 @@ class TestInterpolatorTet(TestCase):
     nrefs = 1
 
     def runTest(self):
-        m = self.mesh_type()
-        m.refine(self.nrefs)
+        m = self.mesh_type().refined(self.nrefs)
         basis = InteriorBasis(m, self.element_type())
         x = project(lambda x: x[0] ** 2, basis_to=basis)
         fun = basis.interpolator(x)
@@ -204,8 +201,7 @@ class TestInterpolatorLine2(TestInterpolatorTet):
 )
 def test_trace(mtype, e1, e2):
 
-    m = mtype()
-    m.refine(3)
+    m = mtype().refined(3)
 
     # use the boundary where last coordinate is zero
     basis = FacetBasis(m, e1,

--- a/tests/test_convergence.py
+++ b/tests/test_convergence.py
@@ -45,7 +45,7 @@ class ConvergenceQ1(unittest.TestCase):
 
         for itr in range(Nitrs):
             if itr > 0:
-                m.refine()
+                m = m.refined()
             ib = self.create_basis(m)
 
             A = asm(laplace, ib)

--- a/tests/test_convergence.py
+++ b/tests/test_convergence.py
@@ -144,8 +144,7 @@ class ConvergenceQ1(unittest.TestCase):
         return InteriorBasis(m, e)
 
     def setUp(self):
-        self.mesh = MeshQuad()
-        self.mesh.refine(2)
+        self.mesh = MeshQuad().refined(2)
 
 
 class ConvergenceQ2(ConvergenceQ1):
@@ -158,8 +157,7 @@ class ConvergenceQ2(ConvergenceQ1):
         return InteriorBasis(m, e)
 
     def setUp(self):
-        self.mesh = MeshQuad()
-        self.mesh.refine(2)
+        self.mesh = MeshQuad().refined(2)
 
 
 class ConvergenceQuadS2(ConvergenceQ2):
@@ -176,8 +174,7 @@ class ConvergenceTriP1(ConvergenceQ1):
         return InteriorBasis(m, e)
 
     def setUp(self):
-        self.mesh = MeshTri.init_sqsymmetric()
-        self.mesh.refine(2)
+        self.mesh = MeshTri.init_sqsymmetric().refined(2)
 
 
 class ConvergenceTriP2(ConvergenceTriP1):
@@ -210,8 +207,7 @@ class ConvergenceTriHermite(ConvergenceTriP1):
         ))
 
     def setUp(self):
-        self.mesh = MeshTri.init_symmetric()
-        self.mesh.refine(2)
+        self.mesh = MeshTri.init_symmetric().refined(2)
 
 
 class ConvergenceTriCR(ConvergenceTriP1):
@@ -242,8 +238,7 @@ class ConvergenceHex1(ConvergenceQ1):
         return InteriorBasis(m, e)
 
     def setUp(self):
-        self.mesh = MeshHex()
-        self.mesh.refine(2)
+        self.mesh = MeshHex().refined(2)
 
 
 class ConvergenceHexS2(ConvergenceQ1):
@@ -257,8 +252,7 @@ class ConvergenceHexS2(ConvergenceQ1):
         return InteriorBasis(m, e)
 
     def setUp(self):
-        self.mesh = MeshHex()
-        self.mesh.refine(1)
+        self.mesh = MeshHex().refined(1)
 
 
 class ConvergenceHex2(ConvergenceHexS2):
@@ -282,8 +276,7 @@ class ConvergenceTetP1(ConvergenceQ1):
         return InteriorBasis(m, e)
 
     def setUp(self):
-        self.mesh = MeshTet()
-        self.mesh.refine(2)
+        self.mesh = MeshTet().refined(2)
 
 
 class ConvergenceTetCR(ConvergenceTetP1):
@@ -307,8 +300,7 @@ class ConvergenceTetP2(ConvergenceTetP1):
         return InteriorBasis(m, e)
 
     def setUp(self):
-        self.mesh = MeshTet()
-        self.mesh.refine(1)
+        self.mesh = MeshTet().refined(1)
 
 
 class ConvergenceTetMini(ConvergenceTetP1):
@@ -325,8 +317,7 @@ class ConvergenceLineP1(ConvergenceQ1):
         return InteriorBasis(m, e)
 
     def setUp(self):
-        self.mesh = MeshLine()
-        self.mesh.refine(3)
+        self.mesh = MeshLine().refined(3)
 
 
 class ConvergenceLineP2(ConvergenceQ1):
@@ -339,8 +330,7 @@ class ConvergenceLineP2(ConvergenceQ1):
         return InteriorBasis(m, e)
 
     def setUp(self):
-        self.mesh = MeshLine()
-        self.mesh.refine(3)
+        self.mesh = MeshLine().refined(3)
 
 class ConvergenceLineMini(ConvergenceLineP2):
     
@@ -396,8 +386,7 @@ class FacetConvergenceTetP2(unittest.TestCase):
         L2err = np.array([])
 
         for itr in range(0, 3):
-            m = self.case[0]()
-            m.refine(self.preref + itr)
+            m = self.case[0]().refined(self.preref + itr)
 
             ib = InteriorBasis(m, self.case[1]())
             fb = FacetBasis(m, self.case[1]())

--- a/tests/test_convergence_h2.py
+++ b/tests/test_convergence_h2.py
@@ -70,7 +70,7 @@ class ConvergenceMorley(TestCase):
 
             L2s.append(L2)
             hs.append(m.param())
-            m.refine()
+            m = m.refined()
 
         hs = np.array(hs)
         L2s = np.array(L2s)
@@ -139,7 +139,7 @@ class ConvergenceHermite(TestCase):
 
             L2s.append(L2)
             hs.append(m.param())
-            m.refine()
+            m = m.refined()
 
         hs = np.array(hs)
         L2s = np.array(L2s)

--- a/tests/test_convergence_h2.py
+++ b/tests/test_convergence_h2.py
@@ -17,8 +17,7 @@ class ConvergenceMorley(TestCase):
     abs_limit = 8e-5
 
     def runTest(self):
-        m = self.case[0]()
-        m.refine(self.prerefs)
+        m = self.case[0]().refined(self.prerefs)
 
         hs = []
         L2s = []
@@ -105,8 +104,7 @@ class ConvergenceHermite(TestCase):
     abs_limit = 8e-5
 
     def runTest(self):
-        m = self.case[0]()
-        m.refine(self.prerefs)
+        m = self.case[0]().refined(self.prerefs)
 
         hs = []
         L2s = []

--- a/tests/test_convergence_hdiv.py
+++ b/tests/test_convergence_hdiv.py
@@ -69,7 +69,7 @@ class ConvergenceRaviartThomas(unittest.TestCase):
             Hdivs[itr] = self.compute_Hdiv(m, ib1, sigma)
             hs[itr] = m.param()
 
-            m.refine()
+            m = m.refined()
 
         rateL2 = np.polyfit(np.log(hs), np.log(L2s), 1)[0]
         rateHdiv = np.polyfit(np.log(hs), np.log(Hdivs), 1)[0]

--- a/tests/test_convergence_hdiv.py
+++ b/tests/test_convergence_hdiv.py
@@ -132,8 +132,7 @@ class ConvergenceRaviartThomas(unittest.TestCase):
                 InteriorBasis(m, e0, intorder=2))
 
     def setUp(self):
-        self.mesh = MeshTri()
-        self.mesh.refine(4)
+        self.mesh = MeshTri().refined(4)
 
 
 class ConvergenceRaviartThomas3D(ConvergenceRaviartThomas):
@@ -150,5 +149,4 @@ class ConvergenceRaviartThomas3D(ConvergenceRaviartThomas):
                 InteriorBasis(m, e0, intorder=2))
 
     def setUp(self):
-        self.mesh = MeshTet()
-        self.mesh.refine(1)
+        self.mesh = MeshTet().refined(1)

--- a/tests/test_manufactured.py
+++ b/tests/test_manufactured.py
@@ -30,8 +30,7 @@ class Line1D(unittest.TestCase):
     e = ElementLineP1()
 
     def runTest(self):
-        m = MeshLine(np.linspace(0., 1.))
-        m.refine(2)
+        m = MeshLine(np.linspace(0., 1.)).refined(2)
         ib = InteriorBasis(m, self.e)
         fb = FacetBasis(m, self.e)
 
@@ -68,8 +67,7 @@ class LineNegative1D(unittest.TestCase):
     e = ElementLineP1()
 
     def runTest(self):
-        m = MeshLine(np.linspace(0., 1.))
-        m.refine(2)
+        m = MeshLine(np.linspace(0., 1.)).refined(2)
         ib = InteriorBasis(m, self.e)
         m.define_boundary('left' ,lambda x: x[0] == 0.0)
         m.define_boundary('right', lambda x: x[0] == 1.0)
@@ -109,8 +107,7 @@ class LineNeumann1D(unittest.TestCase):
     e = ElementLineP1()
 
     def runTest(self):
-        m = MeshLine(np.linspace(0., 1.))
-        m.refine(2)
+        m = MeshLine(np.linspace(0., 1.)).refined(2)
         ib = InteriorBasis(m, self.e)
         fb = FacetBasis(m, self.e)
 
@@ -148,8 +145,7 @@ class TestExactHexElement(unittest.TestCase):
 
     def runTest(self):
 
-        m = self.mesh()
-        m.refine(3)
+        m = self.mesh().refined(3)
 
         ib = InteriorBasis(m, self.elem())
 

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -14,8 +14,7 @@ class TestIsoparamNormals(unittest.TestCase):
     elem = ElementHex1
 
     def runTest(self):
-        m = self.mesh()
-        m.refine()
+        m = self.mesh().refined()
         e = self.elem()
         fb = FacetBasis(m, e)
         x = fb.global_coordinates().value
@@ -101,11 +100,8 @@ class TestMortarPair(unittest.TestCase):
     translate_y = 0.0
 
     def init_meshes(self):
-        m1 = self.mesh1_type()
-        m1.refine(self.nrefs1)
-        m2 = self.mesh2_type()
-        m2.refine(self.nrefs2)
-        m2.translate((1.0, self.translate_y))
+        m1 = self.mesh1_type().refined(self.nrefs1)
+        m2 = self.mesh2_type().refined(self.nrefs2).translated((1.0, self.translate_y))
         return m1, m2
 
     def runTest(self):

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -83,8 +83,7 @@ class RefinePreserveSubsets(unittest.TestCase):
 
     def runTest(self):
         for mtype in (MeshLine, MeshTri, MeshQuad):
-            m = mtype()
-            m.refine(2)
+            m = mtype().refined(2)
             boundaries = [('external', lambda x: x[0] * (1. - x[0]) == 0.0),
                           ('internal', lambda x: x[0] == 0.5)]
             for name, handle in boundaries:
@@ -107,8 +106,7 @@ class SaveLoadCycle(unittest.TestCase):
 
     def runTest(self):
         from tempfile import NamedTemporaryFile
-        m = self.cls()
-        m.refine(2)
+        m = self.cls().refined(2)
         f = NamedTemporaryFile(delete=False)
         m.save(f.name + ".vtk")
         with self.assertWarnsRegex(UserWarning, '^Unable to load tagged'):
@@ -131,8 +129,7 @@ class SerializeUnserializeCycle(unittest.TestCase):
 
     def runTest(self):
         for cls in self.clss:
-            m = cls()
-            m.refine(2)
+            m = cls().refined(2)
             m.boundaries = {'down': m.facets_satisfying(lambda x: x[0] == 0)}
             m.subdomains = {'up': m.elements_satisfying(lambda x: x[0] > 0.5)}
             M = cls.from_dict(m.to_dict())
@@ -150,12 +147,11 @@ class TestBoundaryEdges(unittest.TestCase):
         m = MeshTet()
         # default mesh has all edges on the boundary
         self.assertEqual(len(m.boundary_edges()), m.edges.shape[1])
-        m.refine()
         # check that there is a correct amount of boundary edges:
         # 12 (cube edges) * 2 (per cube edge)
         # + 6 (cube faces) * 8 (per cube face)
         # = 72 edges
-        self.assertTrue(len(m.boundary_edges()) == 72)
+        self.assertTrue(len(m.refined().boundary_edges()) == 72)
 
 
 class TestBoundaryEdges2(unittest.TestCase):
@@ -164,12 +160,11 @@ class TestBoundaryEdges2(unittest.TestCase):
         m = MeshHex()
         # default mesh has all edges on the boundary
         self.assertTrue(len(m.boundary_edges()) == m.edges.shape[1])
-        m.refine()
         # check that there is a correct amount of boundary edges:
         # 12 (cube edges) * 2 (per cube edge)
         # + 6 (cube faces) * 4 (per cube face)
         # = 48 edges
-        self.assertEqual(len(m.boundary_edges()), 48)
+        self.assertEqual(len(m.refined().boundary_edges()), 48)
 
 
 class TestMeshAddition(unittest.TestCase):

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -88,12 +88,12 @@ class RefinePreserveSubsets(unittest.TestCase):
                           ('internal', lambda x: x[0] == 0.5)]
             for name, handle in boundaries:
                 m.define_boundary(name, handle, boundaries_only=False)
-            m.refine()
+            m = m.refined()
             for name, handle in boundaries:
                 A = np.sort(m.boundaries[name])
                 B = np.sort(m.facets_satisfying(handle))
                 self.assertTrue((A == B).all())
-            m.refine(2)
+            m = m.refined(2)
             for name, handle in boundaries:
                 A = np.sort(m.boundaries[name])
                 B = np.sort(m.facets_satisfying(handle))
@@ -196,7 +196,7 @@ class TestMeshQuadSplit(unittest.TestCase):
     def runRefineTest(self):
         mesh = MeshQuad()
         mesh.define_boundary('left', lambda x: x[0] == 0)
-        mesh.refine()
+        mesh = mesh.refined()
         mesh_tri = mesh.to_meshtri()
 
         for b in mesh.boundaries:
@@ -213,7 +213,7 @@ class TestAdaptiveSplitting1D(unittest.TestCase):
         for itr in range(10):
             prev_t_size = m.t.shape[1]
             prev_p_size = m.p.shape[1]
-            m.refine([prev_t_size - 1])
+            m = m.refined([prev_t_size - 1])
 
             # check that new size is current size + 1
             self.assertEqual(prev_t_size, m.t.shape[1] - 1)
@@ -232,7 +232,7 @@ class TestAdaptiveSplitting2D(unittest.TestCase):
                 else m.t.shape[1] - 1
             prev_t_size = m.t.shape[1]
             prev_p_size = m.p.shape[1]
-            m.refine([red_ix])
+            m = m.refined([red_ix])
 
             # check that new size is current size + 4
             self.assertEqual(prev_t_size, m.t.shape[1] - 4)

--- a/tests/test_p_convergence.py
+++ b/tests/test_p_convergence.py
@@ -12,8 +12,7 @@ class ConvergenceLinePp(unittest.TestCase):
     """Solve up to floating point precision."""
 
     def setUp(self):
-        self.mesh = MeshLine()
-        self.mesh.refine(3)
+        self.mesh = MeshLine().refined(3)
 
     def create_basis(self, m, p):
         e = ElementLinePp(p)
@@ -69,8 +68,7 @@ class ConvergenceQuadP(unittest.TestCase):
     """Solve up to floating point precision."""
 
     def setUp(self):
-        self.mesh = MeshQuad()
-        self.mesh.refine(1)
+        self.mesh = MeshQuad().refined(1)
         self.mesh.p[:, self.mesh.interior_nodes()] +=\
             0.05 * self.mesh.p[:, self.mesh.interior_nodes()]
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,8 +10,7 @@ from skfem.utils import L2_projection
 
 class InitializeScalarField(unittest.TestCase):
     def runTest(self):
-        mesh = MeshTri()
-        mesh.refine(5)
+        mesh = MeshTri().refined(5)
         basis = InteriorBasis(mesh, ElementTriP1())
 
         def fun(x, y):


### PR DESCRIPTION
There are a lot of uses of `Mesh.refine`, aren't there.  This switches most of them to the new functional `Mesh.refined` in partial fulfillment of #541.  Some of the others might need a closer look, but hopefully that will be easier with this lot out of the way.