### PR TITLE
Start fixing types for numpy 1.20.0

### DIFF
--- a/skfem/assembly/basis/basis.py
+++ b/skfem/assembly/basis/basis.py
@@ -22,11 +22,11 @@ class Basis:
 
     """
 
-    tind: ndarray = None
-    dx: ndarray = None
-    basis: List[ndarray] = [None]
-    X: ndarray = None
-    W: ndarray = None
+    tind: Optional[ndarray] = None
+    dx: ndarray
+    basis: List[Tuple[DiscreteField, ...]] = []
+    X: ndarray
+    W: ndarray
 
     def __init__(self,
                  mesh: Mesh,
@@ -259,16 +259,16 @@ class Basis:
     def split_indices(self) -> List[ndarray]:
         """Return indices for the solution components."""
         if isinstance(self.elem, ElementComposite):
-            o = np.zeros(4, dtype=np.int)
-            output = [None] * len(self.elem.elems)
+            o = np.zeros(4, dtype=np.int_)
+            output: List[ndarray] = []
             for k in range(len(self.elem.elems)):
                 e = self.elem.elems[k]
-                output[k] = np.concatenate((
+                output.append(np.concatenate((
                     self.nodal_dofs[o[0]:(o[0] + e.nodal_dofs)].flatten(),
                     self.edge_dofs[o[1]:(o[1] + e.edge_dofs)].flatten(),
                     self.facet_dofs[o[2]:(o[2] + e.facet_dofs)].flatten(),
                     self.interior_dofs[o[3]:(o[3] + e.interior_dofs)].flatten()
-                )).astype(np.int)
+                )).astype(np.int_))
                 o += np.array([e.nodal_dofs,
                                e.edge_dofs,
                                e.facet_dofs,
@@ -296,7 +296,7 @@ class Basis:
     def zero_w(self) -> ndarray:
         """Return a zero array with correct dimensions for
         :func:`~skfem.assembly.asm`."""
-        return np.zeros((self.nelems, len(self.W)))
+        return np.zeros((self.nelems, 0 if self.W is None else len(self.W)))
 
     def zeros(self) -> ndarray:
         """Return a zero array with same dimensions as the solution."""

--- a/skfem/assembly/basis/exterior_facet_basis.py
+++ b/skfem/assembly/basis/exterior_facet_basis.py
@@ -104,6 +104,7 @@ class ExteriorFacetBasis(Basis):
                        x: ndarray,
                        elem: Element) -> ndarray:
         """Trace mesh basis projection."""
+
         from skfem.utils import project
 
         fbasis = ExteriorFacetBasis(self.mesh,
@@ -112,11 +113,14 @@ class ExteriorFacetBasis(Basis):
                                     quadrature=(self.X, self.W))
         I = fbasis.get_dofs(self.find).all()
         if len(I) == 0:  # special case: no facet DOFs
-            if fbasis.dofs.interior_dofs.shape[0] > 1:
-                # no one-to-one restriction: requires interpolation
-                raise NotImplementedError
-            # special case: piecewise constant elem
-            I = fbasis.dofs.interior_dofs[:, self.tind].flatten()
+            if fbasis.dofs.interior_dofs is not None:
+                if fbasis.dofs.interior_dofs.shape[0] > 1:
+                    # no one-to-one restriction: requires interpolation
+                    raise NotImplementedError
+                # special case: piecewise constant elem
+                I = fbasis.dofs.interior_dofs[:, self.tind].flatten()
+            else:
+                raise ValueError
         return project(x, self, fbasis, I=I)
 
     def trace(self,

--- a/skfem/assembly/dofs.py
+++ b/skfem/assembly/dofs.py
@@ -1,4 +1,4 @@
-from typing import Union, NamedTuple, Any, List
+from typing import Union, NamedTuple, Any, List, Optional
 
 import numpy as np
 from numpy import ndarray
@@ -159,12 +159,12 @@ class DofsView(NamedTuple):
 class Dofs:
     """An object containing a set of degree-of-freedom indices."""
 
-    nodal_dofs: ndarray = None
-    facet_dofs: ndarray = None
-    edge_dofs: ndarray = None
-    interior_dofs: ndarray = None
+    nodal_dofs: Optional[ndarray] = None
+    facet_dofs: Optional[ndarray] = None
+    edge_dofs: Optional[ndarray] = None
+    interior_dofs: Optional[ndarray] = None
 
-    element_dofs: ndarray = None
+    element_dofs: Optional[ndarray] = None
     N: int = 0
 
     topo: Mesh
@@ -280,8 +280,8 @@ class Dofs:
     def _by_name(self,
                  dofs: ndarray,
                  off: int = 0,
-                 ix: ndarray = None,
-                 rows: ndarray = None):
+                 ix: Optional[ndarray] = None,
+                 rows: Optional[Union[List[int], ndarray]] = None):
 
         n_dofs = dofs.shape[0]
         n_ents = dofs.shape[1] if ix is None else len(ix)

--- a/skfem/assembly/form/functional.py
+++ b/skfem/assembly/form/functional.py
@@ -1,4 +1,5 @@
-from typing import Dict, Optional
+from typing import Dict, Optional, Any
+from numbers import Number
 
 from numpy import ndarray
 
@@ -31,7 +32,7 @@ class Functional(Form):
     def assemble(self,
                  ubasis: Basis,
                  vbasis: Optional[Basis] = None,
-                 **kwargs) -> float:
+                 **kwargs) -> Any:
         assert vbasis is None
         vbasis = ubasis
         return self.elemental(vbasis, **kwargs).sum(-1)

--- a/skfem/assembly/form/functional.py
+++ b/skfem/assembly/form/functional.py
@@ -1,5 +1,4 @@
 from typing import Dict, Optional, Any
-from numbers import Number
 
 from numpy import ndarray
 

--- a/skfem/element/discrete_field.py
+++ b/skfem/element/discrete_field.py
@@ -31,7 +31,7 @@ class DiscreteField(NamedTuple):
         return [DiscreteField(*[f[i] for f in self if f is not None])
                 for i in range(self.value.shape[0])]
 
-    def zeros_like(self):
+    def zeros_like(self) -> 'DiscreteField':
         """Return zero :class:`~skfem.element.DiscreteField` with same size."""
 
         def zero_or_none(x):

--- a/skfem/element/element.py
+++ b/skfem/element/element.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Type
+from typing import Optional, List, Type, Tuple
 
 import numpy as np
 from numpy import ndarray
@@ -63,7 +63,7 @@ class Element:
                mapping,
                X: ndarray,
                i: int,
-               tind: Optional[ndarray] = None) -> DiscreteField:
+               tind: Optional[ndarray] = None) -> Tuple[DiscreteField, ...]:
         """Evaluate the global basis functions, given local points X.
 
         The global points - at which the global basis is evaluated at - are

--- a/skfem/element/element_composite.py
+++ b/skfem/element/element_composite.py
@@ -1,4 +1,4 @@
-from typing import List, Any, Union, Optional
+from typing import List, Any
 
 import numpy as np
 from numpy import ndarray

--- a/skfem/element/element_composite.py
+++ b/skfem/element/element_composite.py
@@ -1,9 +1,10 @@
-from typing import List, Any
+from typing import List, Any, Union, Optional
 
 import numpy as np
 from numpy import ndarray
 
 from .element import Element
+from .discrete_field import DiscreteField
 
 
 class ElementComposite(Element):
@@ -14,7 +15,7 @@ class ElementComposite(Element):
 
     """
 
-    def __init__(self, *elems):
+    def __init__(self, *elems: Element):
         self.elems = elems
         self.nodal_dofs = sum([e.nodal_dofs for e in self.elems])
         self.edge_dofs = sum([e.edge_dofs for e in self.elems])
@@ -46,8 +47,9 @@ class ElementComposite(Element):
         self.dofnames = dofnames
 
         doflocs = []
-        for i in range(np.sum(np.array([e._bfun_counts()
-                                        for e in self.elems]))):
+        for i in np.arange(np.sum(np.array([e._bfun_counts()
+                                            for e in self.elems])),
+                           dtype=int):
             n, ind = self._deduce_bfun(i)
             doflocs.append(self.elems[n].doflocs[ind])
         self.doflocs = np.array(doflocs)
@@ -56,7 +58,8 @@ class ElementComposite(Element):
 
     def _deduce_bfun(self, i: int):
         """Deduce component and basis function for i'th index."""
-        counts: ndarray = sum([e._bfun_counts() for e in self.elems])
+        counts = np.sum(np.array([e._bfun_counts()
+                                  for e in self.elems]), axis=0)
         tmp: List[Any] = []
         ns: List[Any] = []
         if counts[0] > 0:
@@ -81,7 +84,7 @@ class ElementComposite(Element):
         for j in range(len(self.elems)):
             maskj = mask == j
             total = np.sum(maskj)
-            seq = np.arange(total, dtype=np.int)
+            seq = np.arange(total, dtype=np.int_)
             inds[maskj] = seq
 
         return ns[i], inds[i]
@@ -89,11 +92,10 @@ class ElementComposite(Element):
     def gbasis(self, mapping, X: ndarray, i: int, tind=None):
         """Call correct :meth:`Element.gbasis` based on ``i``."""
         n, ind = self._deduce_bfun(i)
-        output = []
+        output: List[DiscreteField] = []
         for k, e in enumerate(self.elems):
             if n == k:
                 output.append(e.gbasis(mapping, X, ind, tind)[0])
             else:
-                output.append(e.gbasis(mapping, X, 0, tind)[0]
-                              .zeros_like())
+                output.append(e.gbasis(mapping, X, 0, tind)[0].zeros_like())
         return tuple(output)

--- a/skfem/mesh/mesh.py
+++ b/skfem/mesh/mesh.py
@@ -1,5 +1,7 @@
 import warnings
-from typing import Dict, Optional, Tuple, Type, TypeVar, Union, Callable
+from typing import (Dict, Optional, Tuple,
+                    Type, TypeVar, Union,
+                    Callable, List)
 
 import numpy as np
 from numpy import ndarray
@@ -179,10 +181,10 @@ class Mesh:
                           "persisted when joining meshes.")
         return meshcls(p, t)
 
-    def to_dict(self) -> Dict[str, ndarray]:
+    def to_dict(self) -> Dict[str, Optional[Dict[str, List[float]]]]:
         """Return json serializable dictionary."""
-        boundaries: Optional[Dict[str, ndarray]] = None
-        subdomains: Optional[Dict[str, ndarray]] = None
+        boundaries: Optional[Dict[str, List[float]]] = None
+        subdomains: Optional[Dict[str, List[float]]] = None
         if self.boundaries is not None:
             boundaries = {k: v.tolist() for k, v in self.boundaries.items()}
         if self.subdomains is not None:

--- a/skfem/mesh/mesh3d/mesh3d.py
+++ b/skfem/mesh/mesh3d/mesh3d.py
@@ -66,7 +66,7 @@ class Mesh3D(Mesh):
 
     def interior_edges(self) -> ndarray:
         """Return an array of interior edge indices."""
-        return np.setdiff1d(np.arange(self.edges.shape[1], dtype=np.int),
+        return np.setdiff1d(np.arange(self.edges.shape[1], dtype=np.int64),
                             self.boundary_edges())
 
     def param(self) -> float:

--- a/skfem/quadrature.py
+++ b/skfem/quadrature.py
@@ -3,6 +3,7 @@
 from typing import Tuple
 
 import numpy as np
+from numpy.polynomial.legendre import leggauss
 
 
 def get_quadrature(refdom: str, norder: int) -> Tuple[np.ndarray, np.ndarray]:
@@ -2222,7 +2223,7 @@ def get_quadrature_line(norder: int) -> Tuple[np.ndarray, np.ndarray]:
     """Return a nth order accurate quadrature rule for line [0,1]."""
     if norder <= 1:
         norder = 2
-    X, W = np.polynomial.legendre.leggauss(int(np.ceil((norder + 1.0) / 2.0)))
+    X, W = leggauss(int(np.ceil((norder + 1.0) / 2.0)))
     return np.array([0.5 * X + 0.5]), W / 2.0
 
 

--- a/skfem/utils.py
+++ b/skfem/utils.py
@@ -196,13 +196,13 @@ def solve(A: spmatrix,
 
     """
     if isinstance(b, spmatrix):
-        return solve_eigen(A, b, x, I, solver, **kwargs)
+        return solve_eigen(A, b, x, I, solver, **kwargs)  # type: ignore
     elif isinstance(b, ndarray):
-        return solve_linear(A, b, x, I, solver, **kwargs)
+        return solve_linear(A, b, x, I, solver, **kwargs)  # type: ignore
     raise NotImplementedError("Provided argument types not supported")
 
 
-def _flatten_dofs(S: DofsCollection) -> ndarray:
+def _flatten_dofs(S: Optional[DofsCollection]) -> Optional[ndarray]:
     if S is None:
         return None
     if isinstance(S, ndarray):
@@ -211,7 +211,7 @@ def _flatten_dofs(S: DofsCollection) -> ndarray:
         return S.flatten()
     elif isinstance(S, dict):
         return np.unique(
-            np.concatenate([S[key].flatten() for key in S])  # type: ignore
+            np.concatenate([S[key].flatten() for key in S])
         )
     raise NotImplementedError("Unable to flatten the given set of DOFs.")
 

--- a/skfem/utils.py
+++ b/skfem/utils.py
@@ -210,8 +210,12 @@ def _flatten_dofs(S: Optional[DofsCollection]) -> Optional[ndarray]:
     elif isinstance(S, DofsView):
         return S.flatten()
     elif isinstance(S, dict):
+        def _flatten_helper(S, key):
+            if key in S and isinstance(S[key], DofsView):
+                return S[key].flatten()
+            raise NotImplementedError
         return np.unique(
-            np.concatenate([S[key].flatten() for key in S])
+            np.concatenate([_flatten_helper(S, key) for key in S])
         )
     raise NotImplementedError("Unable to flatten the given set of DOFs.")
 


### PR DESCRIPTION
Update to numpy 1.20.0 reveals a bunch of issues related to typing. This branch will fix those.

Currently `requirements.txt` will fix `numpy<1.20.0` so remember to change that before merging.