### PR TITLE
Add Basis.with_element and Form.partial

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added: `InteriorFacetBasis` for integrating over the interior facets, e.g.,
   evaluating error estimators with jumps and implementing DG methods.
 - Added: `MortarFacetBasis` for integrating over the mortar mesh.
+- Added: `InteriorBasis.with_element` for reinitializing an equivalent basis
+  that uses a different element.
+- Added: `Form.partial` for applying `functools.partial` to the form function
+  wrapped by `Form`.
 - Fixed: Include explicit Python 3.9 support.
 
 ### [2.4.0] - 2021-01-20

--- a/docs/examples/ex18.py
+++ b/docs/examples/ex18.py
@@ -78,8 +78,7 @@ uvp = solve(*condense(K, f, D=basis['u'].find_dofs()))
 
 velocity, pressure = np.split(uvp, [A.shape[0]])
 
-basis['psi'] = InteriorBasis(mesh, ElementTriP2(),
-                             quadrature=basis['u'].quadrature)
+basis['psi'] = basis['u'].with_element(ElementTriP2())
 A = asm(laplace, basis['psi'])
 vorticity = asm(rot, basis['psi'], w=basis['u'].interpolate(velocity))
 psi = solve(*condense(A, vorticity, D=basis['psi'].find_dofs()))

--- a/docs/examples/ex24.py
+++ b/docs/examples/ex24.py
@@ -52,12 +52,10 @@ uvp = solve(*condense(K, np.zeros_like(uvp), uvp, D=D))
 
 velocity, pressure = np.split(uvp, [A.shape[0]])
 
-basis['psi'] = InteriorBasis(mesh, ElementTriP2())
+basis['psi'] = basis['u'].with_element(ElementTriP2())
 A = asm(laplace, basis['psi'])
 psi = np.zeros(basis['psi'].N)
-vorticity = asm(rot, basis['psi'],
-                w=[basis['psi'].interpolate(velocity[i::2])
-                   for i in range(2)])
+vorticity = asm(rot, basis['psi'], w=basis['u'].interpolate(velocity))
 psi = solve(*condense(A, vorticity, D=basis['psi'].find_dofs()['floor'].all()))
 
 

--- a/docs/examples/ex25.py
+++ b/docs/examples/ex25.py
@@ -50,7 +50,7 @@ t = np.zeros(basis.N)
 t[dofs['floor'].all()] = 1.
 t = solve(*condense(A, np.zeros_like(t), t, I=interior))
 
-basis0 = InteriorBasis(mesh, ElementQuad0(), quadrature=basis.quadrature)
+basis0 = basis.with_element(ElementQuad0())
 t0 = solve(asm(mass, basis0),
            asm(mass, basis, basis0) @ t)
 

--- a/docs/examples/ex27.py
+++ b/docs/examples/ex27.py
@@ -111,7 +111,7 @@ class BackwardFacingStep:
                       for variable, e in self.element.items()}
         self.basis['inlet'] = FacetBasis(self.mesh, self.element['u'],
                                          facets=self.mesh.boundaries['inlet'])
-        self.basis['psi'] = InteriorBasis(self.mesh, ElementTriP2(), intorder=3)
+        self.basis['psi'] = self.basis['u'].with_element(ElementTriP2())
         self.D = np.concatenate([b.all() for b in self.basis['u'].find_dofs().values()])
 
         A = asm(vector_laplace, self.basis['u'])

--- a/docs/examples/ex30.py
+++ b/docs/examples/ex30.py
@@ -111,7 +111,7 @@ pressure = solve(K, -dilatation0,
 
 velocity = flow(pressure)
 
-basis['psi'] = InteriorBasis(mesh, ElementQuad2(), intorder=3)
+basis['psi'] = basis['u'].with_element(ElementQuad2())
 psi = np.zeros(A.shape[0])
 vorticity = asm(rot, basis['psi'], w=basis['u'].interpolate(velocity))
 psi = solve(*condense(asm(laplace, basis['psi']), vorticity, D=basis['psi'].find_dofs()))

--- a/docs/examples/ex33.py
+++ b/docs/examples/ex33.py
@@ -50,7 +50,7 @@ D = basis.find_dofs()
 
 x = solve(*condense(A, f, D=D))
 
-y_basis = InteriorBasis(m, ElementVectorH1(ElementTetP1()))
+y_basis = basis.with_element(ElementVectorH1(ElementTetP1()))
 y = project(x, basis, y_basis)
 
 if __name__ == '__main__':

--- a/skfem/assembly/basis/basis.py
+++ b/skfem/assembly/basis/basis.py
@@ -307,4 +307,3 @@ class Basis:
     def with_element(self, elem: Element) -> 'Basis':
         """Create a copy of ``self`` that uses different element."""
         raise NotImplementedError
-

--- a/skfem/assembly/basis/basis.py
+++ b/skfem/assembly/basis/basis.py
@@ -22,6 +22,8 @@ class Basis:
 
     """
 
+    mesh: Mesh
+    elem: Element
     tind: Optional[ndarray] = None
     dx: ndarray
     basis: List[Tuple[DiscreteField, ...]] = []
@@ -301,3 +303,8 @@ class Basis:
     def zeros(self) -> ndarray:
         """Return a zero array with same dimensions as the solution."""
         return np.zeros(self.N)
+
+    def with_element(self, elem: Element) -> 'Basis':
+        """Create a copy of ``self`` that uses different element."""
+        raise NotImplementedError
+

--- a/skfem/assembly/basis/interior_basis.py
+++ b/skfem/assembly/basis/interior_basis.py
@@ -144,3 +144,13 @@ class InteriorBasis(Basis):
             return w
 
         return interpfun
+
+    def with_element(self, elem: Element) -> 'InteriorBasis':
+
+        return type(self)(
+            self.mesh,
+            elem,
+            mapping=self.mapping,
+            quadrature=self.quadrature,
+            elements=self.tind,
+        )

--- a/skfem/assembly/form/form.py
+++ b/skfem/assembly/form/form.py
@@ -1,5 +1,7 @@
 import warnings
 from typing import Callable, Any, Optional
+from functools import partial
+from copy import deepcopy
 
 import numpy as np
 from numpy import ndarray
@@ -18,11 +20,18 @@ class FormDict(dict):
 
 class Form:
 
+    form: Optional[Callable] = None
+
     def __init__(self,
-                 form: Callable = None,
+                 form: Optional[Callable] = None,
                  dtype: type = np.float64):
-        self.form = form
+        self.form = form.form if isinstance(form, Form) else form
         self.dtype = dtype
+
+    def partial(self, *args, **kwargs):
+        form = deepcopy(self)
+        form.form = partial(form.form, *args, **kwargs)
+        return form
 
     def __call__(self, *args):
         if self.form is None:  # decorate

--- a/skfem/models/general.py
+++ b/skfem/models/general.py
@@ -5,15 +5,23 @@ from .helpers import dot, div, curl
 
 
 @BilinearForm
-def divergence(u, v, w):
+def divu(u, v, w):
     return div(u) * v
+
+
+divergence = divu
+
+
+@BilinearForm
+def curluv(u, v, w):
+    return dot(curl(u), v)
 
 
 @LinearForm
 def rot(v, w):
-    return dot(curl(v), w.w)
+    return dot(curl(v), w['w'])
 
 
 @LinearForm
 def vrot(v, w):
-    return dot(v, curl(w.w))
+    return dot(v, curl(w['w']))


### PR DESCRIPTION
@gdmcbain I'm proposing the addition of `Form.partial` which uses `functools.partial` on the actual form function and, thus, allows specializing them for different use cases. I also added `Basis.with_element` because it is a common pattern to initialize the same `Basis` but using different element.

Thus, if you have form such as
```python
@BilinearForm
def curluv(u, v, w):
    return dot(curl(u), v)
```
you can make it equivalent to
```python
@LinearForm
def rot(v, w):
    return dot(curl(w['w']), v)
```
by first casting it to `LinearForm` and then applying `Form.partial`:
```python
LinearForm(curluv).partial(basis.interpolate(w))
```

Also fixes #548.

Remaining work:
- [x] Add changelog entry