### PR TITLE
Fix the omission of None

### DIFF
--- a/docs/howto.rst
+++ b/docs/howto.rst
@@ -24,7 +24,7 @@ partial differential equation.  Here are some general guidelines:
   :class:`~skfem.element.ElementHex2`, for standard second-order problems.
 * Discretize vectorial problems either by manually building the block matrices
   (e.g., using ``scipy.sparse.bmat``) with scalar elements, or by using
-  :class:`~skfem.element.ElementVectorH1` or
+  :class:`~skfem.element.ElementVector` or
   :class:`~skfem.element.ElementComposite` that abstract out the creation of
   the block matrices.
 * Pay special attention to constrained problems, e.g., the Stokes system which

--- a/skfem/element/__init__.py
+++ b/skfem/element/__init__.py
@@ -11,9 +11,9 @@ elements.
 from .discrete_field import DiscreteField
 from .element import Element
 from .element_h1 import ElementH1
-from .element_vector_h1 import ElementVectorH1
 from .element_hdiv import ElementHdiv
 from .element_hcurl import ElementHcurl
+from .element_vector import ElementVector
 from .element_tri import (ElementTriP1, ElementTriP2, ElementTriDG,
                           ElementTriP0, ElementTriRT0, ElementTriMorley,
                           ElementTriArgyris, ElementTriMini, ElementTriCR,
@@ -32,10 +32,15 @@ from .element_line import (ElementLineP0, ElementLineP1, ElementLineP2,
 from .element_composite import ElementComposite  # noqa
 
 
+# for backwards compatibility
+ElementVectorH1 = ElementVector
+
+
 __all__ = [
     "DiscreteField",
     "Element",
     "ElementH1",
+    "ElementVector",
     "ElementVectorH1",
     "ElementHdiv",
     "ElementHcurl",

--- a/skfem/element/element_vector.py
+++ b/skfem/element/element_vector.py
@@ -3,7 +3,7 @@ from .element import Element
 from .discrete_field import DiscreteField
 
 
-class ElementVectorH1(Element):
+class ElementVector(Element):
 
     def __init__(self, elem):
         self.dim = elem.dim

--- a/skfem/element/element_vector_h1.py
+++ b/skfem/element/element_vector_h1.py
@@ -35,8 +35,9 @@ class ElementVectorH1(Element):
         fields = []
         for field in self.elem.gbasis(mapping, X, ind, tind)[0]:
             if field is None:
-                continue
-            tmp = np.zeros((self.dim,) + field.shape)
-            tmp[n] = field
-            fields.append(tmp)
+                fields.append(None)
+            else:
+                tmp = np.zeros((self.dim,) + field.shape)
+                tmp[n] = field
+                fields.append(tmp)
         return (DiscreteField(*fields),)

--- a/skfem/utils.py
+++ b/skfem/utils.py
@@ -14,7 +14,7 @@ from scipy.sparse import spmatrix
 
 from skfem.assembly import asm, BilinearForm, LinearForm, DofsView
 from skfem.assembly.basis import Basis
-from skfem.element import ElementVectorH1
+from skfem.element import ElementVector
 
 
 # custom types for describing input and output values
@@ -428,7 +428,7 @@ def project(fun,
     @BilinearForm
     def mass(u, v, w):
         p = u * v
-        return sum(p) if isinstance(basis_to.elem, ElementVectorH1) else p
+        return sum(p) if isinstance(basis_to.elem, ElementVector) else p
 
     @LinearForm
     def funv(v, w):
@@ -439,7 +439,7 @@ def project(fun,
                           "take only one argument in the future.",
                           DeprecationWarning)
             p = fun(*w.x) * v
-        return sum(p) if isinstance(basis_to.elem, ElementVectorH1) else p
+        return sum(p) if isinstance(basis_to.elem, ElementVector) else p
 
     @BilinearForm
     def deriv(u, v, w):


### PR DESCRIPTION
In principle, `ElementVectorH1` works for any `Element` but there was a bug which caused it not to work.

TODO:
- [x] Rename to `ElementVector`
- [x] Add alias `ElementVectorH1` for backwards compatibility and deprecate it