### PR TITLE
Make all components of DiscreteField.hod separate

### DIFF
--- a/skfem/element/discrete_field.py
+++ b/skfem/element/discrete_field.py
@@ -13,7 +13,8 @@ class DiscreteField(NamedTuple):
     div: Optional[ndarray] = None
     curl: Optional[ndarray] = None
     hess: Optional[ndarray] = None
-    hod: Optional[ndarray] = None
+    grad3: Optional[ndarray] = None
+    grad4: Optional[ndarray] = None
 
     def __array__(self):
         return self.value

--- a/skfem/element/discrete_field.py
+++ b/skfem/element/discrete_field.py
@@ -15,6 +15,8 @@ class DiscreteField(NamedTuple):
     hess: Optional[ndarray] = None
     grad3: Optional[ndarray] = None
     grad4: Optional[ndarray] = None
+    grad5: Optional[ndarray] = None
+    grad6: Optional[ndarray] = None
 
     def __array__(self):
         return self.value
@@ -41,6 +43,16 @@ class DiscreteField(NamedTuple):
             return np.zeros_like(x)
 
         return DiscreteField(*[zero_or_none(field) for field in self])
+
+    @property
+    def hod(self):
+        """For backwards compatibility."""
+        return np.array([
+            self.grad3,
+            self.grad4,
+            self.grad5,
+            self.grad6,
+        ], dtype=object)
 
     @property
     def f(self):

--- a/skfem/element/element_global.py
+++ b/skfem/element/element_global.py
@@ -41,17 +41,16 @@ class ElementGlobal(Element):
                     U[k][diff] += (V[:, itr, i][:, None]
                                    * self._pbasis[diff][itr](*x))
 
-        # put higher order derivatives into a single array
-        hod = np.empty((self.derivatives - 2,), dtype=object)
+        hod = {}
         for k in range(self.derivatives - 2):
-            hod[k] = U[k + 3]
+            hod['grad{}'.format(k + 3)] = U[k + 3]
 
         return (
             DiscreteField(
                 value=U[0],
                 grad=U[1],
                 hess=U[2],
-                hod=hod,
+                **hod
             ),
         )
 

--- a/skfem/helpers.py
+++ b/skfem/helpers.py
@@ -59,12 +59,12 @@ def dd(u: DiscreteField):
 
 def ddd(u):
     """Third derivative (if available)."""
-    return u.hod[0]
+    return u.grad3
 
 
 def dddd(u):
     """Fourth derivative (if available)."""
-    return u.hod[1]
+    return u.grad4
 
 
 def dot(u: FieldOrArray, v: FieldOrArray):


### PR DESCRIPTION
I was trying to use `ElementGlobal.derivative > 2` with `ElementVector` and it failed. By splitting `DiscreteField.hod` into `DiscreteField.grad3`, `DiscreteField.grad4`, and so on will make it hopefully more compatible with other features of the package.