### PR TITLE
remove minor type violations

### DIFF
--- a/docs/examples/ex04.py
+++ b/docs/examples/ex04.py
@@ -105,7 +105,7 @@ limit = 0.3
 # assemble the stiffness matrices
 K1 = asm(weakform1, ib)
 K2 = asm(weakform2, Ib)
-K = [[K1, 0.], [0., K2]]
+K_blocks = [[K1, 0.], [0., K2]]
 f = [None] * 2
 
 
@@ -127,7 +127,7 @@ for i in range(2):
             return ((1. / (alpha * w.h) * ju * jv - mu * jv - mv * ju)
                     * (np.abs(w.x[1]) <= limit))
 
-        K[i][j] += asm(bilin_mortar, mb[j], mb[i])
+        K_blocks[i][j] += asm(bilin_mortar, mb[j], mb[i])
 
     @LinearForm
     def lin_mortar(v, w):
@@ -139,7 +139,7 @@ for i in range(2):
     f[i] = asm(lin_mortar, mb[i])
 
 import scipy.sparse
-K = (scipy.sparse.bmat(K)).tocsr()
+K = (scipy.sparse.bmat(K_blocks)).tocsr()
 
 # set boundary conditions and solve
 i1 = np.arange(K1.shape[0])

--- a/docs/examples/ex22.py
+++ b/docs/examples/ex22.py
@@ -65,17 +65,19 @@ if __name__ == "__main__":
     from skfem.visuals.matplotlib import draw, plot, show
     draw(m)
 
-for itr in range(9): # 9 adaptive refinements
-    if itr > 0:
-        m = m.refined(adaptive_theta(eval_estimator(m, u)))
+for itr in reversed(range(9)):
         
     basis = InteriorBasis(m, e)
     
     K = asm(laplace, basis)
     f = asm(load, basis)
-    
+
     I = m.interior_nodes()
     u = solve(*condense(K, f, I=I))
+        
+    if itr > 0:
+        m = m.refined(adaptive_theta(eval_estimator(m, u)))
+
 
 if __name__ == "__main__":
     draw(m)

--- a/docs/examples/ex24.py
+++ b/docs/examples/ex24.py
@@ -83,7 +83,7 @@ if __name__ == '__main__':
             color='k')
 
     n_streamlines = 11
-    plot = partial(ax.tricontour,
+    contour = partial(ax.tricontour,
                    Triangulation(*mesh.p, mesh.t.T),
                    psi[basis['psi'].nodal_dofs.flatten()],
                    linewidths=1.)
@@ -95,7 +95,7 @@ if __name__ == '__main__':
              'r', 'solid'),
             (np.linspace(min(psi), 0, n_streamlines)[:-1],
              'g', 'solid')]:
-        plot(levels=levels, colors=color, linestyles=style)
+        contour(levels=levels, colors=color, linestyles=style)
 
     ax.set_aspect(1.)
     ax.axis('off')

--- a/docs/examples/ex24.py
+++ b/docs/examples/ex24.py
@@ -84,9 +84,9 @@ if __name__ == '__main__':
 
     n_streamlines = 11
     contour = partial(ax.tricontour,
-                   Triangulation(*mesh.p, mesh.t.T),
-                   psi[basis['psi'].nodal_dofs.flatten()],
-                   linewidths=1.)
+                      Triangulation(*mesh.p, mesh.t.T),
+                      psi[basis['psi'].nodal_dofs.flatten()],
+                      linewidths=1.)
     for levels, color, style in [
             (np.linspace(0, 2/3, n_streamlines),
              'k',

--- a/skfem/io/json.py
+++ b/skfem/io/json.py
@@ -1,13 +1,14 @@
 """Import mesh from JSON as defined by :class:`skfem.mesh.to_dict`."""
 
 import json
+from os import PathLike
 from typing import Type
 
 from skfem.mesh import (MeshLine, MeshTri, MeshQuad,
                         MeshTet, MeshHex, Mesh)
 
 
-def from_file(filename: str) -> Mesh:
+def from_file(filename: PathLike) -> Mesh:
     with open(filename, 'r') as handle:
         d = json.load(handle)
 


### PR DESCRIPTION
Following the recent discussion of mypy in #573 I promised to look into it and began by running
```shell
mypy docs/examples
```
This turns up a lot (368) of
> docs/examples/ex37.py:9: error: Name 'MeshTet' is not defined

which I assume follows from 

https://github.com/kinnala/scikit-fem/blob/8763b9e415035acb8de406bd7e35ba89d7290f29/docs/examples/ex37.py#L4

but also a much smaller number of miscellaneous things which I've fixed here.  (Names of variables being reused for things of different type, `skfem.json.io.from_file` expecting `str` whereas really it passes `filename` to `open` which wants `os.PathLike`, minor things.)