### PR TITLE
Cache kernels

### DIFF
--- a/skfem/assembly/basis/basis.py
+++ b/skfem/assembly/basis/basis.py
@@ -1,5 +1,6 @@
 import warnings
 from typing import Any, Dict, List, Optional, Tuple, Type, Union
+from functools import lru_cache
 
 import numpy as np
 from numpy import ndarray
@@ -9,6 +10,7 @@ from skfem.mapping import Mapping
 from skfem.mesh import Mesh
 from skfem.quadrature import get_quadrature
 from skfem.refdom import Refdom
+from skfem.generic_utils import HashableNdArray
 
 
 class Basis:
@@ -97,8 +99,14 @@ class Basis:
     @property
     def element_dofs(self):
         if self.tind is None:
+            return self.get_element_dofs(None)
+        return self.get_element_dofs(HashableNdArray(self.tind))
+
+    @lru_cache(maxsize=128)
+    def get_element_dofs(self, tind):
+        if tind is None:
             return self.dofs.element_dofs
-        return self.dofs.element_dofs[:, self.tind]
+        return self.dofs.element_dofs[:, tind]
 
     def complement_dofs(self, *D):
         if type(D[0]) is dict:

--- a/skfem/assembly/form/bilinear_form.py
+++ b/skfem/assembly/form/bilinear_form.py
@@ -1,9 +1,11 @@
 from typing import Optional, Any
+from functools import lru_cache
 
 import numpy as np
 
 from .form import Form, FormDict
 from ..basis import Basis
+from skfem.generic_utils import HashableNdArray
 
 
 class BilinearForm(Form):
@@ -72,39 +74,46 @@ class BilinearForm(Form):
                              "should have same number of integration points.")
 
         nt = ubasis.nelems
-        dx = ubasis.dx
+        dx = HashableNdArray(ubasis.dx)
+
         wdict = FormDict({
             **ubasis.default_parameters(),
             **self.dictify(kwargs)
         })
 
         # initialize COO data structures
+        # Each data[i] rows[i] cols[i] triplet corresponds to an integral over
+        # a single element between basis functions rows[i] and cols[i].
         sz = ubasis.Nbfun * vbasis.Nbfun * nt
         data = np.zeros(sz, dtype=self.dtype)
-        rows = np.zeros(sz)
-        cols = np.zeros(sz)
+        rows = np.zeros(sz, dtype='int64')
+        cols = np.zeros(sz, dtype='int64')
 
         # loop over the indices of local stiffness matrix
+        ixs = 0  # Track index in the (data, rows, cols) triplets.
         for j in range(ubasis.Nbfun):
             for i in range(vbasis.Nbfun):
-                ixs = slice(nt * (vbasis.Nbfun * j + i),
-                            nt * (vbasis.Nbfun * j + i + 1))
-                rows[ixs] = vbasis.element_dofs[i]
-                cols[ixs] = ubasis.element_dofs[j]
-                data[ixs] = self._kernel(
+                d = self._kernel(
                     ubasis.basis[j],
                     vbasis.basis[i],
                     wdict,
                     dx
                 )
+                if (d != np.zeros_like(d)).any():
+                    r = vbasis.element_dofs[i]
+                    ix_slice = slice(ixs, ixs + len(r))
+                    rows[ix_slice] = r
+                    cols[ix_slice] = ubasis.element_dofs[j]
+                    data[ix_slice] = d
+                    ixs += len(r)
 
-        # TODO: allow user to change, e.g. cuda or petsc
         return self._assemble_scipy_matrix(
-            data,
-            rows,
-            cols,
+            data[0:ixs],
+            rows[0:ixs],
+            cols[0:ixs],
             (vbasis.N, ubasis.N)
         )
 
+    @lru_cache(maxsize=128)
     def _kernel(self, u, v, w, dx):
         return np.sum(self.form(*u, *v, w) * dx, axis=1)

--- a/skfem/assembly/form/form.py
+++ b/skfem/assembly/form/form.py
@@ -14,12 +14,31 @@ from ...element import DiscreteField
 class FormDict(dict):
     """Passed to forms as 'w'."""
 
+    # Immutable and hashable for caching of other functions as Python default
+    # caching requires hashability of function arguments.
+    def __init__(self, *args, **kwargs):
+        super(FormDict, self).__init__(*args, **kwargs)
+        self._hash = None
+
     def __getattr__(self, attr):
         return self[attr].value
 
+    def __hash__(self):
+        if self._hash is None:
+            sorted_keys = tuple(sorted(self.keys()))
+            self._hash = hash((sorted_keys, (self[k] for k in sorted_keys)))
+        return self._hash
+
+    def __setattr__(self, key, value):
+        if key != '_hash':
+            raise Exception('FormDict is immutable.')
+        super(FormDict, self).__setattr__('_hash', value)
+
+    def __setitem__(self, key, value):
+        raise Exception('FormDict is immutable.')
+
 
 class Form:
-
     form: Optional[Callable] = None
 
     def __init__(self,

--- a/skfem/element/discrete_field.py
+++ b/skfem/element/discrete_field.py
@@ -1,10 +1,12 @@
-from typing import NamedTuple, Optional
+from typing import Optional
 
 import numpy as np
 from numpy import ndarray
+from dataclasses import dataclass
 
 
-class DiscreteField(NamedTuple):
+@dataclass
+class DiscreteField:
     """A function defined at the global quadrature points."""
 
     value: ndarray
@@ -16,6 +18,36 @@ class DiscreteField(NamedTuple):
     grad4: Optional[ndarray] = None
     grad5: Optional[ndarray] = None
     grad6: Optional[ndarray] = None
+
+    def __post_init__(self):
+        self.as_tuple = (self.value, self.grad, self.div, self.curl,
+                         self.hess, self.grad3, self.grad4,
+                         self.grad5, self.grad6)
+        all_data = tuple(f.tobytes() if f is not None else None for f in self)
+        self._hash = hash(all_data)
+
+    def __getitem__(self, item):
+        return self.as_tuple[item]
+
+    def __len__(self):
+        return len(self.as_tuple)
+
+    def __hash__(self):
+        return self._hash
+
+    def __eq__(self, other):
+        if not isinstance(other, DiscreteField):
+            return False
+        for i in range(len(self.as_tuple)):
+            if self[i] is None and other[i] is None:
+                continue
+            elif self[i] is None or other[i] is None:
+                return False
+            elif (self[i] == other[i]).all():
+                continue
+            else:
+                return False
+        return True
 
     def __array__(self):
         return self.value
@@ -76,4 +108,4 @@ class DiscreteField(NamedTuple):
                 return None
             return np.zeros_like(x)
 
-        return DiscreteField(*[zero_or_none(field) for field in self])
+        return DiscreteField(*[zero_or_none(field) for field in self.as_tuple])

--- a/skfem/generic_utils.py
+++ b/skfem/generic_utils.py
@@ -1,0 +1,30 @@
+import numpy as np
+
+
+class HashableNdArray(np.ndarray):
+    # Immutable np.ndarray with hashing support. Intended for enabling caching
+    # in other functions as default Python caching requires hashability of
+    # function arguments.
+    # Note that if HashableNdArray is used to wrap an existing np.ndarray,
+    # the HashableNdArray becomes a view of the underlying array. Therefore
+    # modifying the underlying array is likely to break things.
+
+    def __new__(cls, *args, **kwargs):
+        if len(args) == 1 and len(kwargs) == 0 and \
+                isinstance(args[0], np.ndarray):
+            obj = np.asarray(args[0]).view(cls)
+            obj._hash = None
+            obj.flags.writeable = False
+        else:
+            obj = super(HashableNdArray, cls).__new__(cls, *args, **kwargs)
+        obj.flags.writeable = False
+        return obj
+
+    def __hash__(self):
+        if self._hash is None:
+            self._hash = hash(self.tobytes())
+        return self._hash
+
+    def __eq__(self, other):
+        if isinstance(other, HashableNdArray):
+            return (self.__array__() == other.__array__()).all()


### PR DESCRIPTION
I'm not sure if this is a good idea in the mainline. Feel free to deny this PR.

Caching _kernel evaluations is extremely beneficial in my use cases as I often use a composite element basis. Basically this allows skipping the evaluation of _kernel(..) when the basis consists of zeros. The basis can be zeros when CompositeElements are 

I found that in order to get reasonable performance on MacroElements (see: [WIP commit](https://github.com/topikuu/scikit-fem/commit/dd5619679f2a2e2b5bd91ffafc36c908a5614ef8)) really need either this or a rather extensive modification to dofs.py and bilin_assembly.
The modification would consist of:
- Changing dofs.element_dofs into a list of arrays of different lengths (instead of current ndarray) as all elements don't have all the basis functions.
- Finding the intersection of basis supports in bilin_assembly before _kernel evaluations. Bookkeeping the indexing gets non-trivial but is doable.
- A ton of small changes all over the place as a lot of things seem to rely on all elements having all the basis functions.

Is it justifiable to add this complexity to the mainstream to support, quite frankly, obscure and rarely used elements?
