### PR TITLE
Performance improvements

### DIFF
--- a/docs/examples/performance.py
+++ b/docs/examples/performance.py
@@ -18,26 +18,31 @@ print('| Degrees-of-freedom | Assembly (s) | Linear solve (s) |')
 print('| --- | --- | --- |')
 
 
+def assembler(m):
+    basis = InteriorBasis(m, ElementTetP1())
+    return (
+        asm(laplace, basis),
+        asm(unit_load, basis),
+    )
+
+
 for k in range(6, 21):
 
     m = pre(int(2 ** (k / 3)))
 
-    def assembler(m):
-        basis = InteriorBasis(m, ElementTetP1())
-        return (asm(laplace, basis),
-                asm(unit_load, basis),
-                m.boundary_nodes())
-
-    A, b, D = assembler(m)
-
     assemble_time = timeit(lambda: assembler(m), number=1)
 
-    def solver(A, b):
-        return solve(*condense(A, b, D=D))
+    A, b = assembler(m)
+    D = m.boundary_nodes()
 
     if A.shape[0] > 1e5:
         solve_time = np.nan
     else:
-        solve_time = timeit(lambda: solver(A, b), number=1)
+        solve_time = timeit(lambda: solve(*condense(A, b, D=D)), number=1)
 
     print('| {} | {:.5f} | {:.5f} |'.format(len(b), assemble_time, solve_time))
+
+    del A
+    del b
+    del D
+    del m

--- a/skfem/assembly/basis/interior_basis.py
+++ b/skfem/assembly/basis/interior_basis.py
@@ -158,7 +158,7 @@ class InteriorBasis(Basis):
         return interpfun
 
     def with_element(self, elem: Element) -> 'InteriorBasis':
-
+        """Return a similar basis using a different element."""
         return type(self)(
             self.mesh,
             elem,

--- a/skfem/assembly/basis/interior_basis.py
+++ b/skfem/assembly/basis/interior_basis.py
@@ -68,11 +68,10 @@ class InteriorBasis(Basis):
                       for j in range(self.Nbfun)]
 
         if elements is None:
-            self.nelems = mesh.t.shape[1]
-            self.tind = np.arange(self.nelems, dtype=np.int64)
+            self.nelems = mesh.nelements
         else:
             self.nelems = len(elements)
-            self.tind = elements
+        self.tind = elements
 
         self.dx = (np.abs(self.mapping.detDF(self.X, tind=elements))
                    * np.tile(self.W, (self.nelems, 1)))

--- a/skfem/assembly/dofs.py
+++ b/skfem/assembly/dofs.py
@@ -182,7 +182,7 @@ class Dofs:
         offset = element.nodal_dofs * topo.nvertices
 
         # edge dofs
-        if element.dim == 3:
+        if element.dim == 3 and element.edge_dofs > 0:
             self.edge_dofs = np.reshape(
                 np.arange(element.edge_dofs * topo.nedges,
                           dtype=np.int64),
@@ -193,12 +193,15 @@ class Dofs:
             self.edge_dofs = np.empty((0, 0), dtype=np.int64)
 
         # facet dofs
-        self.facet_dofs = np.reshape(
-            np.arange(element.facet_dofs * topo.nfacets,
-                      dtype=np.int64),
-            (element.facet_dofs, topo.nfacets),
-            order='F') + offset
-        offset += element.facet_dofs * topo.nfacets
+        if element.facet_dofs > 0:
+            self.facet_dofs = np.reshape(
+                np.arange(element.facet_dofs * topo.nfacets,
+                          dtype=np.int64),
+                (element.facet_dofs, topo.nfacets),
+                order='F') + offset
+            offset += element.facet_dofs * topo.nfacets
+        else:
+            self.facet_dofs = np.empty((0, 0), dtype=np.int64)
 
         # interior dofs
         self.interior_dofs = np.reshape(
@@ -217,7 +220,7 @@ class Dofs:
             ))
 
         # edge dofs
-        if element.dim == 3:
+        if element.dim == 3 and element.edge_dofs > 0:
             for itr in range(topo.t2e.shape[0]):
                 self.element_dofs = np.vstack((
                     self.element_dofs,
@@ -225,7 +228,7 @@ class Dofs:
                 ))
 
         # facet dofs
-        if element.dim >= 2:
+        if element.dim >= 2 and element.facet_dofs > 0:
             for itr in range(topo.t2f.shape[0]):
                 self.element_dofs = np.vstack((
                     self.element_dofs,

--- a/skfem/mesh/mesh.py
+++ b/skfem/mesh/mesh.py
@@ -276,8 +276,10 @@ class Mesh:
                 self._cached_mapping = MappingAffine(self)
             else:
                 # TODO make MappingIsoparametric compatible with self
-                FakeMesh = namedtuple('FakeMesh',
-                                      ['p', 't', 'facets', 't2f', 'f2t', 'dim'])
+                FakeMesh = namedtuple(
+                    'FakeMesh',
+                    ['p', 't', 'facets', 't2f', 'f2t', 'dim']
+                )
                 fakemesh = FakeMesh(
                     self.doflocs,
                     self.dofs.element_dofs,

--- a/skfem/mesh/mesh.py
+++ b/skfem/mesh/mesh.py
@@ -275,6 +275,7 @@ class Mesh:
             if self.affine:
                 self._cached_mapping = MappingAffine(self)
             else:
+                # TODO make MappingIsoparametric compatible with self
                 FakeMesh = namedtuple('FakeMesh',
                                       ['p', 't', 'facets', 't2f', 'f2t', 'dim'])
                 fakemesh = FakeMesh(

--- a/skfem/mesh/mesh.py
+++ b/skfem/mesh/mesh.py
@@ -272,19 +272,19 @@ class Mesh:
         """Return a default reference mapping for the mesh."""
         from skfem.mapping import MappingAffine, MappingIsoparametric
         if not hasattr(self, '_cached_mapping'):
-            FakeMesh = namedtuple('FakeMesh',
-                                  ['p', 't', 'facets', 't2f', 'f2t', 'dim'])
-            fakemesh = FakeMesh(
-                self.doflocs,
-                self.dofs.element_dofs,
-                self.facets,
-                self.t2f,
-                self.f2t,
-                lambda: self.dim(),
-            )
             if self.affine:
-                self._cached_mapping = MappingAffine(fakemesh)
+                self._cached_mapping = MappingAffine(self)
             else:
+                FakeMesh = namedtuple('FakeMesh',
+                                      ['p', 't', 'facets', 't2f', 'f2t', 'dim'])
+                fakemesh = FakeMesh(
+                    self.doflocs,
+                    self.dofs.element_dofs,
+                    self.facets,
+                    self.t2f,
+                    self.f2t,
+                    lambda: self.dim(),
+                )
                 self._cached_mapping = MappingIsoparametric(
                     fakemesh,
                     self.elem(),


### PR DESCRIPTION
- Prevent unnecessary initialization of `Mesh.facets` and `Mesh.edges` in the constructor of `Dofs` if the element has no facet or edge dofs
- Stop using `FakeMesh` for initializing `MappingAffine` because that requires initializing `self.facets`