### PR TITLE
basis_to is not Optional in utils.projection

### DIFF
--- a/skfem/utils.py
+++ b/skfem/utils.py
@@ -397,7 +397,7 @@ def adaptive_theta(est, theta=0.5, max=None):
 
 
 def projection(fun,
-               basis_to: Optional[Basis] = None,
+               basis_to: Basis,
                basis_from: Optional[Basis] = None,
                diff: Optional[int] = None,
                I: Optional[ndarray] = None,


### PR DESCRIPTION
It's needed here

https://github.com/kinnala/scikit-fem/blob/93844bb32d6823eb7386a58a77a40e4b3b7e2472/skfem/utils.py#L445

and `None` won't work.