### PR TITLE
real-if-close when drawing a MeshTet 

### DIFF
--- a/docs/examples/ex21.py
+++ b/docs/examples/ex21.py
@@ -90,5 +90,5 @@ L, x = solve(*enforce(K, M, D=ib.find_dofs()['fixed']))
 if __name__ == "__main__":
     from skfem.visuals.matplotlib import draw, show
     sf = 2.0
-    draw(MeshTet(np.array(m.p + sf * x[ib.nodal_dofs, 0]), m.t))
+    draw(MeshTet(np.real_if_close(m.p + sf * x[ib.nodal_dofs, 0]), m.t))
     show()


### PR DESCRIPTION
This is a minimal alternative to #611 for fixing #609, using `real_if_close` rather than `real`.  There are other aspects of #609 discussed there and under #611 though.
