### PR TITLE
revert to condense from enforce, passing symmetric solver

### DIFF
--- a/docs/examples/ex03.py
+++ b/docs/examples/ex03.py
@@ -3,7 +3,6 @@
 from skfem import *
 from skfem.helpers import dot
 from skfem.models.elasticity import linear_elasticity
-from scipy.sparse.linalg import eigsh
 import numpy as np
 
 m1 = MeshLine(np.linspace(0, 5, 50))
@@ -31,9 +30,9 @@ y = gb.zeros()
 
 I = gb.complement_dofs(D)
 
-L, x = eigsh(K[I].T[I].T, k=6, M=M[I].T[I].T, which='SM')
+L, x = solve(*condense(K, M, I=I), solver=solver_eigen_scipy_sym(k=6, sigma=0.0))
 
-y[I] = x[:, 4]
+y = x[:, 4]
 
 if __name__ == "__main__":
     from skfem.visuals.matplotlib import draw, show

--- a/docs/examples/ex21.py
+++ b/docs/examples/ex21.py
@@ -85,7 +85,9 @@ def mass(u, v, w):
 
 M = asm(mass, ib)
 
-L, x = solve(*enforce(K, M, D=ib.find_dofs()['fixed']))
+L, x = solve(
+    *condense(K, M, D=ib.find_dofs()["fixed"]), solver=solver_eigen_scipy_sym()
+)
 
 if __name__ == "__main__":
     from skfem.visuals.matplotlib import draw, show

--- a/docs/examples/ex31.py
+++ b/docs/examples/ex31.py
@@ -40,7 +40,7 @@ basis = InteriorBasis(m, e)
 A = asm(laplace, basis)
 M = asm(mass, basis)
 
-L, x = solve(*condense(A, M, D=basis.find_dofs()), k=8)
+L, x = solve(*condense(A, M, D=basis.find_dofs()), solver=solver_eigen_scipy_sym(k=8))
 
 if __name__ == '__main__':
 


### PR DESCRIPTION
This takes ex21 back to where it was before #591 and #596, thereby avoiding having to excise the spurious imaginary part introduced by the asymmetric eigensolver as in #611 or #612.

Eventually it might be possible to `enforce` rather than condense the Dirichlet conditions, but I don't think it's quite clear yet how to do this for generalized eigenvalue problems.