### PR TITLE
avoid MatplotlibDeprecationWarning for Axes3d

### DIFF
--- a/docs/examples/ex21.py
+++ b/docs/examples/ex21.py
@@ -85,7 +85,9 @@ def mass(u, v, w):
 
 M = asm(mass, ib)
 
-L, x = solve(*enforce(K, M, D=ib.find_dofs()['fixed']))
+L, x = solve(
+    *condense(K, M, D=ib.find_dofs()["fixed"]), solver=solver_eigen_scipy_sym()
+)
 
 if __name__ == "__main__":
     from skfem.visuals.matplotlib import draw, show

--- a/skfem/visuals/matplotlib.py
+++ b/skfem/visuals/matplotlib.py
@@ -3,7 +3,6 @@
 from functools import singledispatch
 
 import numpy as np
-from mpl_toolkits.mplot3d import Axes3D
 from numpy import ndarray
 
 import matplotlib.pyplot as plt

--- a/skfem/visuals/matplotlib.py
+++ b/skfem/visuals/matplotlib.py
@@ -35,8 +35,7 @@ def draw_basis(ib: InteriorBasis, **kwargs) -> Axes:
 def draw_meshtet(m: MeshTet, **kwargs) -> Axes:
     """Visualize a tetrahedral mesh by drawing the boundary facets."""
     bnd_facets = m.boundary_facets()
-    fig = plt.figure()
-    ax = Axes3D(fig)
+    ax = plt.figure().add_subplot(1, 1, 1, projection='3d')
     indexing = m.facets[:, bnd_facets].T
     ax.plot_trisurf(m.p[0], m.p[1], m.p[2],
                     triangles=indexing, cmap=plt.cm.viridis, edgecolor='k')
@@ -263,11 +262,7 @@ def plot3_meshtri(m: MeshTri, z: ndarray, **kwargs) -> Axes:
         The Matplotlib axes onto which the mesh was plotted.
 
     """
-    if "ax" not in kwargs:
-        fig = plt.figure()
-        ax = Axes3D(fig)
-    else:
-        ax = kwargs["ax"]
+    ax = kwargs.get("ax", plt.figure().add_subplot(1, 1, 1, projection='3d'))
 
     ax.plot_trisurf(m.p[0], m.p[1], z,
                     triangles=m.t.T,


### PR DESCRIPTION
This lets exx10, 21 run without warnings.  It's atop #613 which is required by ex21.