### PR TITLE
Optionally assemble using multiple threads

### DIFF
--- a/skfem/assembly/form/form.py
+++ b/skfem/assembly/form/form.py
@@ -23,9 +23,11 @@ class Form:
 
     def __init__(self,
                  form: Optional[Callable] = None,
-                 dtype: type = np.float64):
+                 dtype: type = np.float64,
+                 nthreads: int = 0):
         self.form = form.form if isinstance(form, Form) else form
         self.dtype = dtype
+        self.nthreads = nthreads
 
     def partial(self, *args, **kwargs):
         form = deepcopy(self)
@@ -34,7 +36,9 @@ class Form:
 
     def __call__(self, *args):
         if self.form is None:  # decorate
-            return type(self)(form=args[0], dtype=self.dtype)
+            return type(self)(form=args[0],
+                              dtype=self.dtype,
+                              nthreads=self.nthreads)
         return self.assemble(self.kernel(*args))
 
     def assemble(self,


### PR DESCRIPTION
As discussed in #450. Here is a snippet that I used to verify the performance gain:
```python
import numpy as np
from skfem import *
from numba import jit

m = MeshTet().refined(5)
basis = InteriorBasis(m, ElementTetP2())

@jit(nogil=True, nopython=True)
def nlaplace(out, du, dv):
    for i in range(du.shape[1]):
        for j in range(du.shape[2]):
            for k in range(du.shape[0]):
                out[i, j] += du[k, i, j] * dv[k, i, j]

@BilinearForm(nthreads=4)
def bilinf(u, v, w):
    out = np.empty_like(u.grad[0])
    nlaplace(out, u.grad, v.grad)
    return out

A = bilinf.assemble(basis)
```