### PR TITLE
Meshline element finder

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Unreleased
 
+- Fixed: `MeshLine1.element_finder` 
+
 ### [3.0.0] - 2021-04-19
 
 - Added: Completely rewritten `Mesh` base class which is "immutable" and uses

--- a/skfem/mesh/mesh.py
+++ b/skfem/mesh/mesh.py
@@ -1321,7 +1321,7 @@ class MeshLine1(Mesh):
             maxix = (x == np.max(self.p))
             x[maxix] = x[maxix] - 1e-10  # special case in np.digitize
             return np.argmax(np.digitize(x, self.p[0, ix[0]])[:, None]
-                             == self.t[0], axis=1)
+                             == self.t[1], axis=1)
 
         return finder
 


### PR DESCRIPTION
For #628.

[`numpy.digitize`](https://numpy.org/doc/stable/reference/generated/numpy.digitize.html?highlight=digitize#numpy.digitize) returns the right end-point, so compare with `self.t[1]` rather than `self.t[0]`.

