### PR TITLE
MeshLine1.element_finder

### DIFF
--- a/skfem/mesh/mesh.py
+++ b/skfem/mesh/mesh.py
@@ -1316,12 +1316,14 @@ class MeshLine1(Mesh):
 
     def element_finder(self, mapping=None):
         ix = np.argsort(self.p[0])
-        maxt = self.t[np.argmax(self.p[0, self.t], 0), np.arange(self.t.shape[1])]
+        maxt = self.t[np.argmax(self.p[0, self.t], 0),
+                      np.arange(self.t.shape[1])]
 
         def finder(x):
-            xin = x.copy()
-            xin[x == self.p[0, ix[-1]]] = self.p[0, ix[-2:]].mean()  # endpoint in np.digitize
-            return np.nonzero(ix[np.digitize(xin, self.p[0, ix])][:, None] == maxt)[1]
+            xin = x.copy()  # bring endpoint inside for np.digitize
+            xin[x == self.p[0, ix[-1]]] = self.p[0, ix[-2:]].mean()
+            return np.nonzero(ix[np.digitize(xin, self.p[0, ix])][:, None] 
+                              == maxt)[1]
 
         return finder
 

--- a/skfem/mesh/mesh.py
+++ b/skfem/mesh/mesh.py
@@ -1322,7 +1322,7 @@ class MeshLine1(Mesh):
         def finder(x):
             xin = x.copy()  # bring endpoint inside for np.digitize
             xin[x == self.p[0, ix[-1]]] = self.p[0, ix[-2:]].mean()
-            return np.nonzero(ix[np.digitize(xin, self.p[0, ix])][:, None] 
+            return np.nonzero(ix[np.digitize(xin, self.p[0, ix])][:, None]
                               == maxt)[1]
 
         return finder

--- a/skfem/mesh/mesh.py
+++ b/skfem/mesh/mesh.py
@@ -1315,15 +1315,13 @@ class MeshLine1(Mesh):
         return np.max(np.abs(self.p[0, self.t[1]] - self.p[0, self.t[0]]))
 
     def element_finder(self, mapping=None):
-        ix = np.argsort(self.p)
-        mint = self.t[np.argmin(self.p[:, self.t], axis=1)[0],
-                      np.arange(self.t.shape[1])]
+        ix = np.argsort(self.p[0])
+        maxt = self.t[np.argmax(self.p[0, self.t], 0), np.arange(self.t.shape[1])]
 
         def finder(x):
-            maxix = (x == np.max(self.p))
-            x[maxix] = x[maxix] - 1e-10  # special case in np.digitize
-            return np.argmax(np.digitize(x, self.p[0, ix[0]])[:, None]
-                             == mint, axis=1)
+            xin = x.copy()
+            xin[x == self.p[0, ix[-1]]] = self.p[0, ix[-2:]].mean()  # endpoint in np.digitize
+            return np.nonzero(ix[np.digitize(xin, self.p[0, ix])][:, None] == maxt)[1]
 
         return finder
 

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -227,7 +227,7 @@ class TestMirrored(TestCase):
         self.assertEqual(m.nelements, 20)
 
 
-class TestFinder1D(TestCase):
+class TestFinder1DRefined(TestCase):
 
     def runTest(self):
 
@@ -235,6 +235,18 @@ class TestFinder1D(TestCase):
             finder = MeshLine().refined(itr).element_finder()
             self.assertEqual(finder(np.array([0.001]))[0], 0)
             self.assertEqual(finder(np.array([0.999]))[0], 2 ** itr - 1)
+
+
+class TestFinder1DLinspaced(TestCase):
+
+    def runTest(self):
+
+        for itr in range(5):
+            finder = (
+                MeshLine(np.linspace(0, 1, 2 ** itr + 1)).element_finder()
+            )
+            self.assertEqual(finder(np.array([0.999]))[0], 2 ** itr - 1)
+            self.assertEqual(finder(np.array([0.001]))[0], 0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Look for right end of cells, to match np.digitizer.

Plus a few minor improvements.  (No need to find the max when we already have the argsort in hand.  Instead of moving a probe point hitting the end in by the hardcoded amount of 1e-10, move it halfway to the penultimate point which is easy as we have the argsort in hand.)