### PR TITLE
Improvements to Mesh.element_finder

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,8 +257,9 @@ with respect to documented and/or tested features.
 - Added: `ElementTriCCR` and `ElementTetCCR`, conforming Crouzeix-Raviart finite elements
 - Fixed: `Mesh.mirrored` returned a wrong mesh when a point other than the origin was used
 - Fixed: `MeshLine` constructor accepted only NumPy arrays and not plain Python lists
-- Fixed: `Mesh.element_finder` (and `CellBasis.probes` and `CellBasis.interpolator`) was not working properly for a small number of elements (<5) or a large number of input points (>1000)
-- Fixed: `MeshTet.element_finder` is now slightly more robust against degenerate tetrahedra
+- Fixed: `Mesh.element_finder` (and `CellBasis.probes`, `CellBasis.interpolator`) was not working properly for a small number of elements (<5) or a large number of input points (>1000)
+- Fixed: `MeshTet` and `MeshTri.element_finder` is are now more robust against degenerate elements
+- Fixed: `Mesh.element_finder` (and `CellBasis.probes`, `CellBasis.interpolator`) raises exception if the query point is outside of the domain
 
 ### [3.1.0] - 2021-06-18
 

--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ with respect to documented and/or tested features.
 - Added: `ElementTriCCR` and `ElementTetCCR`, conforming Crouzeix-Raviart finite elements
 - Fixed: `Mesh.mirrored` returned a wrong mesh when a point other than the origin was used
 - Fixed: `MeshLine` constructor accepted only NumPy arrays and not plain Python lists
+- Fixed: `Mesh.element_finder` (and `CellBasis.probes` and `CellBasis.interpolator`) was not working properly for a small number of elements (<5) or a large number of input points (>1000).
 
 ### [3.1.0] - 2021-06-18
 

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ with respect to documented and/or tested features.
 - Fixed: `Mesh.mirrored` returned a wrong mesh when a point other than the origin was used
 - Fixed: `MeshLine` constructor accepted only NumPy arrays and not plain Python lists
 - Fixed: `Mesh.element_finder` (and `CellBasis.probes` and `CellBasis.interpolator`) was not working properly for a small number of elements (<5) or a large number of input points (>1000)
-- Fixed: `Mesh.element_finder` is now more robust against degenerate triangles and tetrahedra
+- Fixed: `Mesh.element_finder` is now slightly more robust against degenerate tetrahedra
 
 ### [3.1.0] - 2021-06-18
 

--- a/README.md
+++ b/README.md
@@ -257,7 +257,8 @@ with respect to documented and/or tested features.
 - Added: `ElementTriCCR` and `ElementTetCCR`, conforming Crouzeix-Raviart finite elements
 - Fixed: `Mesh.mirrored` returned a wrong mesh when a point other than the origin was used
 - Fixed: `MeshLine` constructor accepted only NumPy arrays and not plain Python lists
-- Fixed: `Mesh.element_finder` (and `CellBasis.probes` and `CellBasis.interpolator`) was not working properly for a small number of elements (<5) or a large number of input points (>1000).
+- Fixed: `Mesh.element_finder` (and `CellBasis.probes` and `CellBasis.interpolator`) was not working properly for a small number of elements (<5) or a large number of input points (>1000)
+- Fixed: `Mesh.element_finder` is now more robust against degenerate triangles and tetrahedra
 
 ### [3.1.0] - 2021-06-18
 

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ with respect to documented and/or tested features.
 - Fixed: `Mesh.mirrored` returned a wrong mesh when a point other than the origin was used
 - Fixed: `MeshLine` constructor accepted only NumPy arrays and not plain Python lists
 - Fixed: `Mesh.element_finder` (and `CellBasis.probes` and `CellBasis.interpolator`) was not working properly for a small number of elements (<5) or a large number of input points (>1000)
-- Fixed: `Mesh.element_finder` is now slightly more robust against degenerate tetrahedra
+- Fixed: `MeshTet.element_finder` is now slightly more robust against degenerate tetrahedra
 
 ### [3.1.0] - 2021-06-18
 

--- a/docs/examples/ex28.py
+++ b/docs/examples/ex28.py
@@ -88,15 +88,7 @@ import numpy as np
 import pygmsh
 
 
-if version.parse(pygmsh.__version__) < version.parse('7.0.0'):
-    class NullContextManager():
-        def __enter__(self):
-            return None
-        def __exit__(self, *args):
-            pass
-    geometrycontext = NullContextManager()
-else:
-    geometrycontext = pygmsh.geo.Geometry()
+geometrycontext = pygmsh.geo.Geometry()
 
 halfheight = 1.
 length = 10.
@@ -111,11 +103,7 @@ def make_mesh(halfheight: float,  # mm
               length: float,
               thickness: float) -> MeshTri:
     with geometrycontext as g:
-        if version.parse(pygmsh.__version__) < version.parse('7.0.0'):
-            geom = pygmsh.built_in.Geometry()
-            geom.add_curve_loop = geom.add_line_loop
-        else:
-            geom = g
+        geom = g
 
         points = []
         lines = []
@@ -155,10 +143,7 @@ def make_mesh(halfheight: float,  # mm
         geom.add_physical(geom.add_plane_surface(geom.add_curve_loop(
             [*lines[-3:], -lines[1]])), 'solid')
 
-        if version.parse(pygmsh.__version__) < version.parse('7.0.0'):
-            return from_meshio(pygmsh.generate_mesh(geom, dim=2))
-        else:
-            return from_meshio(geom.generate_mesh(dim=2))
+        return from_meshio(geom.generate_mesh(dim=2))
 
 mesh = from_file(Path(__file__).parent / 'meshes' / 'ex28.json')
 element = ElementTriP1()

--- a/docs/examples/ex28.py
+++ b/docs/examples/ex28.py
@@ -102,13 +102,12 @@ peclet = 357.
 def make_mesh(halfheight: float,  # mm
               length: float,
               thickness: float) -> MeshTri:
-    with geometrycontext as g:
-        geom = g
+    with geometrycontext as geom:
 
         points = []
         lines = []
 
-        lcar = halfheight / 2**2
+        lcar = halfheight / 2 ** 2
 
         for xy in [(0., halfheight),
                    (0., -halfheight),

--- a/skfem/mesh/mesh_line_1.py
+++ b/skfem/mesh/mesh_line_1.py
@@ -74,6 +74,7 @@ class MeshLine1(Mesh):
         return np.max(np.abs(self.p[0, self.t[1]] - self.p[0, self.t[0]]))
 
     def element_finder(self, mapping=None):
+
         ix = np.argsort(self.p[0])
         maxt = self.t[np.argmax(self.p[0, self.t], 0),
                       np.arange(self.t.shape[1])]
@@ -81,8 +82,11 @@ class MeshLine1(Mesh):
         def finder(x):
             xin = x.copy()  # bring endpoint inside for np.digitize
             xin[x == self.p[0, ix[-1]]] = self.p[0, ix[-2:]].mean()
-            return np.nonzero(ix[np.digitize(xin, self.p[0, ix])][:, None]
-                              == maxt)[1]
+            elems = np.nonzero(ix[np.digitize(xin, self.p[0, ix])][:, None]
+                               == maxt)[1]
+            if len(elems) < len(x):
+                raise ValueError("Point is outside of the mesh.")
+            return elems
 
         return finder
 

--- a/skfem/mesh/mesh_tet_1.py
+++ b/skfem/mesh/mesh_tet_1.py
@@ -1,4 +1,3 @@
-import warnings
 from dataclasses import dataclass, replace
 from typing import Type
 

--- a/skfem/mesh/mesh_tet_1.py
+++ b/skfem/mesh/mesh_tet_1.py
@@ -1,4 +1,3 @@
-import warnings
 from dataclasses import dataclass, replace
 from typing import Type
 
@@ -41,12 +40,13 @@ class MeshTet1(Mesh3D):
         tree = self._cached_tree
         nelems = self.t.shape[1]
 
-        def finder(x, y, z):
+        def finder(x, y, z, ix=None):
 
-            ix = tree.query(np.array([x, y, z]).T,
-                            min(10, nelems))[1].flatten()
-            _, ix_ind = np.unique(ix, return_index=True)
-            ix = ix[np.sort(ix_ind)]
+            if ix is None:
+                ix = tree.query(np.array([x, y, z]).T,
+                                min(10, nelems))[1].flatten()
+                _, ix_ind = np.unique(ix, return_index=True)
+                ix = ix[np.sort(ix_ind)]
 
             X = mapping.invF(np.array([x, y, z])[:, None], ix)
             inside = ((X[0] >= 0) *
@@ -55,7 +55,7 @@ class MeshTet1(Mesh3D):
                       (1 - X[0] - X[1] - X[2] >= 0))
 
             if not inside.max(axis=0).all():
-                warnings.warn("Unable to find elements for all points.")
+                return finder(x, y, z, ix=np.arange(nelems, dtype=np.int64))
 
             return np.array([ix[inside.argmax(axis=0)]]).flatten()
 

--- a/skfem/mesh/mesh_tet_1.py
+++ b/skfem/mesh/mesh_tet_1.py
@@ -40,10 +40,10 @@ class MeshTet1(Mesh3D):
         tree = self._cached_tree
         nelems = self.t.shape[1]
 
-        def finder(x, y, z, ncandidates=8):
+        def finder(x, y, z):
 
             ix = tree.query(np.array([x, y, z]).T,
-                            min(ncandidates, nelems))[1].flatten()
+                            min(10, nelems))[1].flatten()
             if len(ix) > nelems:
                 _, ix_ind = np.unique(ix, return_index=True)
                 ix = ix[np.sort(ix_ind)]

--- a/skfem/mesh/mesh_tet_1.py
+++ b/skfem/mesh/mesh_tet_1.py
@@ -1,3 +1,4 @@
+import warnings
 from dataclasses import dataclass, replace
 from typing import Type
 
@@ -40,22 +41,30 @@ class MeshTet1(Mesh3D):
         tree = self._cached_tree
         nelems = self.t.shape[1]
 
-        def finder(x, y, z):
+        def finder(x, y, z, _exhaustive=False):
 
-            if x.shape[0] > nelems:
-                # search all elements if there is a large number of points
+            if _exhaustive or x.shape[0] > nelems:
+                # search all elements if forced by the flag or if there is a
+                # large number of points
                 ix = None
             else:
                 ix = tree.query(np.array([x, y, z]).T,
                                 min(5, nelems))[1].flatten()
 
             X = mapping.invF(np.array([x, y, z])[:, None], ix)
-            inside = np.argmax((X[0] >= 0) *
-                               (X[1] >= 0) *
-                               (X[2] >= 0) *
-                               (1 - X[0] - X[1] - X[2] >= 0), axis=0)
+            inside = ((X[0] >= 0) *
+                      (X[1] >= 0) *
+                      (X[2] >= 0) *
+                      (1 - X[0] - X[1] - X[2] >= 0))
+            elems = np.argmax(inside, axis=0)
 
-            return inside if ix is None else np.array([ix[inside]]).flatten()
+            if ix is not None and not inside[elems].any(axis=0).all():
+                warnings.warn("Falling back to exhaustive search because the "
+                              "correct element was not among the nearest "
+                              "candidates.")
+                return finder(x, y, z, _exhaustive=True)
+
+            return elems if ix is None else np.array([ix[elems]]).flatten()
 
         return finder
 

--- a/skfem/mesh/mesh_tet_1.py
+++ b/skfem/mesh/mesh_tet_1.py
@@ -40,13 +40,15 @@ class MeshTet1(Mesh3D):
         tree = self._cached_tree
         nelems = self.t.shape[1]
 
-        def finder(x, y, z, ix=None):
+        def finder(x, y, z, _search_all=False):
 
-            if ix is None:
+            if not _search_all:
                 ix = tree.query(np.array([x, y, z]).T,
                                 min(10, nelems))[1].flatten()
                 _, ix_ind = np.unique(ix, return_index=True)
                 ix = ix[np.sort(ix_ind)]
+            else:
+                ix = np.arange(nelems, dtype=np.int64)
 
             X = mapping.invF(np.array([x, y, z])[:, None], ix)
             inside = ((X[0] >= 0) *
@@ -55,7 +57,9 @@ class MeshTet1(Mesh3D):
                       (1 - X[0] - X[1] - X[2] >= 0))
 
             if not inside.max(axis=0).all():
-                return finder(x, y, z, ix=np.arange(nelems, dtype=np.int64))
+                if _search_all:
+                    raise ValueError("Point is outside of the mesh.")
+                return finder(x, y, z, _search_all=True)
 
             return np.array([ix[inside.argmax(axis=0)]]).flatten()
 

--- a/skfem/mesh/mesh_tet_1.py
+++ b/skfem/mesh/mesh_tet_1.py
@@ -1,3 +1,4 @@
+import warnings
 from dataclasses import dataclass, replace
 from typing import Type
 
@@ -52,9 +53,11 @@ class MeshTet1(Mesh3D):
                       (X[1] >= 0) *
                       (X[2] >= 0) *
                       (1 - X[0] - X[1] - X[2] >= 0))
-            elems = np.argmax(inside, axis=0)
 
-            return np.array([ix[elems]]).flatten()
+            if not inside.max(axis=0).all():
+                warnings.warn("Unable to find elements for all points.")
+
+            return np.array([ix[inside.argmax(axis=0)]]).flatten()
 
         return finder
 

--- a/skfem/mesh/mesh_tet_1.py
+++ b/skfem/mesh/mesh_tet_1.py
@@ -44,9 +44,8 @@ class MeshTet1(Mesh3D):
 
             ix = tree.query(np.array([x, y, z]).T,
                             min(10, nelems))[1].flatten()
-            if len(ix) > nelems:
-                _, ix_ind = np.unique(ix, return_index=True)
-                ix = ix[np.sort(ix_ind)]
+            _, ix_ind = np.unique(ix, return_index=True)
+            ix = ix[np.sort(ix_ind)]
 
             X = mapping.invF(np.array([x, y, z])[:, None], ix)
             inside = ((X[0] >= 0) *

--- a/skfem/mesh/mesh_tet_1.py
+++ b/skfem/mesh/mesh_tet_1.py
@@ -42,8 +42,8 @@ class MeshTet1(Mesh3D):
 
         def finder(x, y, z):
 
-            if x.shape[0] > 1e3:
-                # optimize the case with a large number of points
+            if x.shape[0] > nelems:
+                # search all elements if there is a large number of points
                 ix = None
             else:
                 ix = tree.query(np.array([x, y, z]).T,

--- a/skfem/mesh/mesh_tet_1.py
+++ b/skfem/mesh/mesh_tet_1.py
@@ -41,15 +41,13 @@ class MeshTet1(Mesh3D):
         tree = self._cached_tree
         nelems = self.t.shape[1]
 
-        def finder(x, y, z, _exhaustive=False):
+        def finder(x, y, z, ncandidates=8):
 
-            if _exhaustive or x.shape[0] > nelems:
-                # search all elements if forced by the flag or if there is a
-                # large number of points
-                ix = None
-            else:
-                ix = tree.query(np.array([x, y, z]).T,
-                                min(5, nelems))[1].flatten()
+            ix = tree.query(np.array([x, y, z]).T,
+                            min(ncandidates, nelems))[1].flatten()
+            if len(ix) > nelems:
+                _, ix_ind = np.unique(ix, return_index=True)
+                ix = ix[np.sort(ix_ind)]
 
             X = mapping.invF(np.array([x, y, z])[:, None], ix)
             inside = ((X[0] >= 0) *
@@ -58,13 +56,7 @@ class MeshTet1(Mesh3D):
                       (1 - X[0] - X[1] - X[2] >= 0))
             elems = np.argmax(inside, axis=0)
 
-            if ix is not None and not inside[elems].any(axis=0).all():
-                warnings.warn("Falling back to exhaustive search because the "
-                              "correct element was not among the nearest "
-                              "candidates.")
-                return finder(x, y, z, _exhaustive=True)
-
-            return elems if ix is None else np.array([ix[elems]]).flatten()
+            return np.array([ix[elems]]).flatten()
 
         return finder
 

--- a/skfem/mesh/mesh_tri_1.py
+++ b/skfem/mesh/mesh_tri_1.py
@@ -1,4 +1,3 @@
-import warnings
 from dataclasses import dataclass, replace
 from typing import Type
 

--- a/skfem/mesh/mesh_tri_1.py
+++ b/skfem/mesh/mesh_tri_1.py
@@ -328,6 +328,7 @@ class MeshTri1(Mesh2D):
         if not hasattr(self, '_cached_tree'):
             self._cached_tree = cKDTree(np.mean(self.p[:, self.t], axis=1).T)
 
+        nelems = self.t.shape[1]
         tree = self._cached_tree
 
         def finder(x, y):
@@ -336,7 +337,7 @@ class MeshTri1(Mesh2D):
                 # optimize the case with a large number of points
                 ix = None
             else:
-                ix = tree.query(np.array([x, y]).T, 5)[1].flatten()
+                ix = tree.query(np.array([x, y]).T, min(5, nelems))[1].flatten()
 
             X = mapping.invF(np.array([x, y])[:, None], ix)
             inside = np.argmax((X[0] >= 0) *

--- a/skfem/mesh/mesh_tri_1.py
+++ b/skfem/mesh/mesh_tri_1.py
@@ -329,7 +329,6 @@ class MeshTri1(Mesh2D):
             self._cached_tree = cKDTree(np.mean(self.p[:, self.t], axis=1).T)
 
         tree = self._cached_tree
-        nelems = self.t.shape[1]
 
         def finder(x, y):
 
@@ -345,11 +344,11 @@ class MeshTri1(Mesh2D):
                 (X[1] >= 0) *
                 (1 - X[0] - X[1] >= 0)
             )
-            tmp = np.argmax(inside, axis=0)
+            inside_ix = np.argmax(inside, axis=0)
 
             if ix is None:
-                return tmp
+                return inside_ix
 
-            return np.array([ix[tmp]]).flatten()
+            return np.array([ix[inside_ix]]).flatten()
 
         return finder

--- a/skfem/mesh/mesh_tri_1.py
+++ b/skfem/mesh/mesh_tri_1.py
@@ -331,10 +331,10 @@ class MeshTri1(Mesh2D):
         tree = self._cached_tree
         nelems = self.t.shape[1]
 
-        def finder(x, y, ncandidates=5):
+        def finder(x, y):
 
             ix = tree.query(np.array([x, y]).T,
-                            min(ncandidates, nelems))[1].flatten()
+                            min(5, nelems))[1].flatten()
             if len(ix) > nelems:
                 _, ix_ind = np.unique(ix, return_index=True)
                 ix = ix[np.sort(ix_ind)]

--- a/skfem/mesh/mesh_tri_1.py
+++ b/skfem/mesh/mesh_tri_1.py
@@ -1,4 +1,3 @@
-import warnings
 from dataclasses import dataclass, replace
 from typing import Type
 
@@ -332,12 +331,13 @@ class MeshTri1(Mesh2D):
         tree = self._cached_tree
         nelems = self.t.shape[1]
 
-        def finder(x, y):
+        def finder(x, y, ix=None):
 
-            ix = tree.query(np.array([x, y]).T,
-                            min(5, nelems))[1].flatten()
-            _, ix_ind = np.unique(ix, return_index=True)
-            ix = ix[np.sort(ix_ind)]
+            if ix is None:
+                ix = tree.query(np.array([x, y]).T,
+                                min(5, nelems))[1].flatten()
+                _, ix_ind = np.unique(ix, return_index=True)
+                ix = ix[np.sort(ix_ind)]
 
             X = mapping.invF(np.array([x, y])[:, None], ix)
             inside = ((X[0] >= 0) *
@@ -345,7 +345,7 @@ class MeshTri1(Mesh2D):
                       (1 - X[0] - X[1] >= 0))
 
             if not inside.max(axis=0).all():
-                warnings.warn("Unable to find elements for all points.")
+                return finder(x, y, ix=np.arange(nelems, dtype=np.int64))
 
             return np.array([ix[inside.argmax(axis=0)]]).flatten()
 

--- a/skfem/mesh/mesh_tri_1.py
+++ b/skfem/mesh/mesh_tri_1.py
@@ -328,8 +328,8 @@ class MeshTri1(Mesh2D):
         if not hasattr(self, '_cached_tree'):
             self._cached_tree = cKDTree(np.mean(self.p[:, self.t], axis=1).T)
 
-        nelems = self.t.shape[1]
         tree = self._cached_tree
+        nelems = self.t.shape[1]
 
         def finder(x, y):
 

--- a/skfem/mesh/mesh_tri_1.py
+++ b/skfem/mesh/mesh_tri_1.py
@@ -1,3 +1,4 @@
+import warnings
 from dataclasses import dataclass, replace
 from typing import Type
 
@@ -342,8 +343,10 @@ class MeshTri1(Mesh2D):
             inside = ((X[0] >= 0) *
                       (X[1] >= 0) *
                       (1 - X[0] - X[1] >= 0))
-            elems = np.argmax(inside, axis=0)
 
-            return np.array([ix[elems]]).flatten()
+            if not inside.max(axis=0).all():
+                warnings.warn("Unable to find elements for all points.")
+
+            return np.array([ix[inside.argmax(axis=0)]]).flatten()
 
         return finder

--- a/skfem/mesh/mesh_tri_1.py
+++ b/skfem/mesh/mesh_tri_1.py
@@ -337,7 +337,8 @@ class MeshTri1(Mesh2D):
                 # optimize the case with a large number of points
                 ix = None
             else:
-                ix = tree.query(np.array([x, y]).T, min(5, nelems))[1].flatten()
+                ix = tree.query(np.array([x, y]).T,
+                                min(5, nelems))[1].flatten()
 
             X = mapping.invF(np.array([x, y])[:, None], ix)
             inside = np.argmax((X[0] >= 0) *

--- a/skfem/mesh/mesh_tri_1.py
+++ b/skfem/mesh/mesh_tri_1.py
@@ -339,16 +339,10 @@ class MeshTri1(Mesh2D):
                 ix = tree.query(np.array([x, y]).T, 5)[1].flatten()
 
             X = mapping.invF(np.array([x, y])[:, None], ix)
-            inside = (
-                (X[0] >= 0) *
-                (X[1] >= 0) *
-                (1 - X[0] - X[1] >= 0)
-            )
-            inside_ix = np.argmax(inside, axis=0)
+            inside = np.argmax((X[0] >= 0) *
+                               (X[1] >= 0) *
+                               (1 - X[0] - X[1] >= 0), axis=0)
 
-            if ix is None:
-                return inside_ix
-
-            return np.array([ix[inside_ix]]).flatten()
+            return inside if ix is None else np.array([ix[inside]]).flatten()
 
         return finder

--- a/skfem/mesh/mesh_tri_1.py
+++ b/skfem/mesh/mesh_tri_1.py
@@ -335,9 +335,8 @@ class MeshTri1(Mesh2D):
 
             ix = tree.query(np.array([x, y]).T,
                             min(5, nelems))[1].flatten()
-            if len(ix) > nelems:
-                _, ix_ind = np.unique(ix, return_index=True)
-                ix = ix[np.sort(ix_ind)]
+            _, ix_ind = np.unique(ix, return_index=True)
+            ix = ix[np.sort(ix_ind)]
 
             X = mapping.invF(np.array([x, y])[:, None], ix)
             inside = ((X[0] >= 0) *

--- a/skfem/mesh/mesh_tri_1.py
+++ b/skfem/mesh/mesh_tri_1.py
@@ -333,8 +333,8 @@ class MeshTri1(Mesh2D):
 
         def finder(x, y):
 
-            if x.shape[0] > 1e3:
-                # optimize the case with a large number of points
+            if x.shape[0] > nelems:
+                # search all elements if there is a large number of points
                 ix = None
             else:
                 ix = tree.query(np.array([x, y]).T,

--- a/skfem/mesh/mesh_tri_1.py
+++ b/skfem/mesh/mesh_tri_1.py
@@ -331,13 +331,15 @@ class MeshTri1(Mesh2D):
         tree = self._cached_tree
         nelems = self.t.shape[1]
 
-        def finder(x, y, ix=None):
+        def finder(x, y, _search_all=False):
 
-            if ix is None:
+            if not _search_all:
                 ix = tree.query(np.array([x, y]).T,
                                 min(5, nelems))[1].flatten()
                 _, ix_ind = np.unique(ix, return_index=True)
                 ix = ix[np.sort(ix_ind)]
+            else:
+                ix = np.arange(nelems, dtype=np.int64)
 
             X = mapping.invF(np.array([x, y])[:, None], ix)
             inside = ((X[0] >= 0) *
@@ -345,7 +347,9 @@ class MeshTri1(Mesh2D):
                       (1 - X[0] - X[1] >= 0))
 
             if not inside.max(axis=0).all():
-                return finder(x, y, ix=np.arange(nelems, dtype=np.int64))
+                if _search_all:
+                    raise ValueError("Point is outside of the mesh.")
+                return finder(x, y, _search_all=True)
 
             return np.array([ix[inside.argmax(axis=0)]]).flatten()
 

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -6,7 +6,7 @@ from numpy.testing import assert_allclose, assert_almost_equal
 
 from skfem import BilinearForm, asm, solve, condense, projection
 from skfem.mesh import MeshTri, MeshTet, MeshHex, MeshQuad, MeshLine
-from skfem.assembly import InteriorBasis, FacetBasis, Dofs, Functional
+from skfem.assembly import CellBasis, FacetBasis, Dofs, Functional
 from skfem.element import (ElementVectorH1, ElementTriP2, ElementTriP1,
                            ElementTetP2, ElementHexS2, ElementHex2,
                            ElementQuad2, ElementLineP2, ElementTriP0,
@@ -28,7 +28,7 @@ class TestCompositeSplitting(TestCase):
 
         e = ElementVectorH1(ElementTriP2()) * ElementTriP1()
 
-        basis = InteriorBasis(m, e)
+        basis = CellBasis(m, e)
 
         @BilinearForm
         def bilinf(u, p, v, q, w):
@@ -93,7 +93,7 @@ class TestFacetExpansion(TestCase):
 
         m = self.mesh_type().refined(2)
 
-        basis = InteriorBasis(m, self.elem_type())
+        basis = CellBasis(m, self.elem_type())
 
         for fun in [lambda x: x[0] == 0,
                     lambda x: x[0] == 1,
@@ -128,7 +128,7 @@ class TestInterpolatorTet(TestCase):
 
     def runTest(self):
         m = self.mesh_type().refined(self.nrefs)
-        basis = InteriorBasis(m, self.element_type())
+        basis = CellBasis(m, self.element_type())
         x = projection(lambda x: x[0] ** 2, basis)
         fun = basis.interpolator(x)
         X = np.linspace(0, 1, 10)
@@ -187,7 +187,34 @@ class TestIncompatibleMeshElement(TestCase):
         with self.assertRaises(ValueError):
             m = MeshTri()
             e = ElementTetP2()
-            basis = InteriorBasis(m, e)
+            basis = CellBasis(m, e)
+
+
+@pytest.mark.parametrize(
+    "mtype,e,nrefs,npoints",
+    [
+        # (MeshTri, ElementTriP1(), 1, 10), # fails?
+        (MeshTri, ElementTriP1(), 1, 10),
+        (MeshTri, ElementTriP1(), 5, 10),
+        (MeshTri, ElementTriP1(), 1, 3e5),
+        (MeshTet, ElementTetP1(), 1, 10),
+        (MeshTet, ElementTetP1(), 5, 10),
+        # (MeshTet, ElementTetP1(), 1, 3e5), # fails
+        # (MeshQuad, ElementQuad1(), 1, 10), # fails?
+    ]
+)
+def test_interpolator_probes(mtype, e, nrefs, npoints):
+
+    m = mtype().refined(nrefs)
+
+    np.random.seed(0)
+    X = np.random.rand(m.p.shape[0], int(npoints))
+
+    basis = CellBasis(m, e)
+
+    y = np.random.randn(len(basis.zeros()))
+
+    assert_allclose(basis.probes(X) @ y, basis.interpolator(y)(X))
 
 
 @pytest.mark.parametrize(
@@ -215,7 +242,7 @@ def test_trace(mtype, e1, e2):
     # use the boundary where last coordinate is zero
     basis = FacetBasis(m, e1,
                        facets=m.facets_satisfying(lambda x: x[x.shape[0] - 1] == 0.0))
-    xfun = projection(lambda x: x[0], InteriorBasis(m, e1))
+    xfun = projection(lambda x: x[0], CellBasis(m, e1))
     nbasis, y = basis.trace(xfun, lambda p: p[0:(p.shape[0] - 1)], target_elem=e2)
 
     @Functional
@@ -235,7 +262,7 @@ def test_point_source(etype):
     from skfem.models.poisson import laplace
 
     mesh = MeshLine().refined()
-    basis = InteriorBasis(mesh, etype())
+    basis = CellBasis(mesh, etype())
     source = np.array([0.7])
     u = solve(*condense(asm(laplace, basis), basis.point_source(source), D=basis.find_dofs()))
     exact = np.stack([(1 - source) * mesh.p, (1 - mesh.p) * source]).min(0)

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -200,7 +200,8 @@ class TestIncompatibleMeshElement(TestCase):
         (MeshTet, ElementTetP1(), 1, 10),
         (MeshTet, ElementTetP1(), 5, 10),
         (MeshTet, ElementTetP1(), 1, 3e5),
-        # (MeshQuad, ElementQuad1(), 1, 10), # fails?
+        (MeshQuad, ElementQuad1(), 1, 10),
+        (MeshQuad, ElementQuad1(), 1, 3e5),
     ]
 )
 def test_interpolator_probes(mtype, e, nrefs, npoints):
@@ -212,7 +213,7 @@ def test_interpolator_probes(mtype, e, nrefs, npoints):
 
     basis = CellBasis(m, e)
 
-    y = np.random.randn(len(basis.zeros()))
+    y = projection(lambda x: x[0] ** 2, basis)
 
     assert_allclose(basis.probes(X) @ y, basis.interpolator(y)(X))
 

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -193,7 +193,7 @@ class TestIncompatibleMeshElement(TestCase):
 @pytest.mark.parametrize(
     "mtype,e,nrefs,npoints",
     [
-        # (MeshTri, ElementTriP1(), 1, 10), # fails?
+        (MeshTri, ElementTriP1(), 0, 10),
         (MeshTri, ElementTriP1(), 1, 10),
         (MeshTri, ElementTriP1(), 5, 10),
         (MeshTri, ElementTriP1(), 1, 3e5),

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -199,7 +199,7 @@ class TestIncompatibleMeshElement(TestCase):
         (MeshTri, ElementTriP1(), 1, 3e5),
         (MeshTet, ElementTetP1(), 1, 10),
         (MeshTet, ElementTetP1(), 5, 10),
-        # (MeshTet, ElementTetP1(), 1, 3e5), # fails
+        (MeshTet, ElementTetP1(), 1, 3e5),
         # (MeshQuad, ElementQuad1(), 1, 10), # fails?
     ]
 )

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -217,7 +217,8 @@ def test_interpolator_probes(mtype, e, nrefs, npoints):
     y = projection(lambda x: x[0] ** 2, basis)
 
     assert_allclose(basis.probes(X) @ y, basis.interpolator(y)(X))
-    assert_allclose(basis.probes(X) @ y, X[0] ** 2, atol=1e-1)
+    atol = 1e-1 if nrefs <= 1 else 1e-3
+    assert_allclose(basis.probes(X) @ y, X[0] ** 2, atol=atol)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -194,14 +194,15 @@ class TestIncompatibleMeshElement(TestCase):
     "mtype,e,nrefs,npoints",
     [
         (MeshTri, ElementTriP1(), 0, 10),
-        (MeshTri, ElementTriP1(), 1, 10),
+        (MeshTri, ElementTriP2(), 1, 10),
         (MeshTri, ElementTriP1(), 5, 10),
         (MeshTri, ElementTriP1(), 1, 3e5),
-        (MeshTet, ElementTetP1(), 1, 10),
+        (MeshTet, ElementTetP2(), 1, 10),
         (MeshTet, ElementTetP1(), 5, 10),
         (MeshTet, ElementTetP1(), 1, 3e5),
         (MeshQuad, ElementQuad1(), 1, 10),
         (MeshQuad, ElementQuad1(), 1, 3e5),
+        (MeshHex, ElementHex1(), 1, 1e5),
     ]
 )
 def test_interpolator_probes(mtype, e, nrefs, npoints):

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -216,6 +216,7 @@ def test_interpolator_probes(mtype, e, nrefs, npoints):
     y = projection(lambda x: x[0] ** 2, basis)
 
     assert_allclose(basis.probes(X) @ y, basis.interpolator(y)(X))
+    assert_allclose(basis.probes(X) @ y, X[0] ** 2, atol=1e-1)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -265,7 +265,7 @@ def test_finder_simplex(m):
         query_pts = np.random.rand(m.p.shape[0], 500)
         assert_array_equal(
             tri.find_simplex(query_pts.T),
-            finder(*query_pts)
+            finder(*query_pts, ncandidates=15)
         )
 
 

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -253,6 +253,7 @@ class TestFinder1DLinspaced(TestCase):
         (MeshTet(), 0),
         (MeshTet(), 1),
         (MeshTet(), 2),
+        (MeshTet(), 10),
     ]
 )
 def test_finder_simplex(m, seed):

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -245,28 +245,29 @@ class TestFinder1DLinspaced(TestCase):
 
 
 @pytest.mark.parametrize(
-    "m",
+    "m,seed",
     [
-        MeshTri(),
-        MeshTet(),
+        (MeshTri(), 0),
+        (MeshTri(), 1),
+        (MeshTri(), 2),
+        (MeshTet(), 0),
+        (MeshTet(), 1),
+        (MeshTet(), 2),
     ]
 )
-def test_finder_simplex(m):
+def test_finder_simplex(m, seed):
 
-    m = m.refined(3)
-
-    for seed in range(10):
-        np.random.seed(seed)
-        points = np.hstack((m.p, np.random.rand(m.p.shape[0], 100)))
-        tri = Delaunay(points.T)
-        M = type(m)(points, tri.simplices.T)
-        finder = M.element_finder()
-
-        query_pts = np.random.rand(m.p.shape[0], 500)
-        assert_array_equal(
-            tri.find_simplex(query_pts.T),
-            finder(*query_pts, ncandidates=15)
-        )
+    np.random.seed(seed)
+    points = np.hstack((m.p, np.random.rand(m.p.shape[0], 100)))
+    tri = Delaunay(points.T)
+    M = type(m)(points, tri.simplices.T)
+    finder = M.element_finder()
+    
+    query_pts = np.random.rand(m.p.shape[0], 500)
+    assert_array_equal(
+        tri.find_simplex(query_pts.T),
+        finder(*query_pts),
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -253,18 +253,20 @@ class TestFinder1DLinspaced(TestCase):
 )
 def test_finder_simplex(m):
 
-    np.random.seed(0)
     m = m.refined(3)
-    points = np.hstack((m.p, np.random.rand(m.p.shape[0], 100)))
-    tri = Delaunay(points.T)
-    M = type(m)(points, tri.simplices.T)
-    finder = M.element_finder()
 
-    query_pts = np.random.rand(m.p.shape[0], 100)
-    assert_array_equal(
-        tri.find_simplex(query_pts.T),
-        finder(*query_pts)
-    )
+    for seed in range(10):
+        np.random.seed(seed)
+        points = np.hstack((m.p, np.random.rand(m.p.shape[0], 100)))
+        tri = Delaunay(points.T)
+        M = type(m)(points, tri.simplices.T)
+        finder = M.element_finder()
+
+        query_pts = np.random.rand(m.p.shape[0], 500)
+        assert_array_equal(
+            tri.find_simplex(query_pts.T),
+            finder(*query_pts)
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
There is a heuristic optimization in `MeshTri1.element_finder` and `MeshTet1.element_finder` which tries to reduce the number of candidate elements where the query point may reside. The optimization logic looks for the query points inside elements whose midpoints are nearby. However, if the number of input points is large (in comparison to the number of elements), this "optimization" actually leads to a larger number of candidate elements and more memory being allocated.

- As in #668, take only unique candidate elements into consideration. Fixes #666.

Moreover, it was pointed out in #666 that the optimization logic does not work for some meshes with degenerate elements.

- Add a robustness test for randomized Delaunay `MeshTri1`and `MeshTet1`; compare against `scipy.spatial.Delaunay.find_simplex`
- Search all elements if the correct candidate is not found on the first try
- Increase the maximum number of candidate elements in `MeshTet1.element_finder`

While testing the new implementation it was found out that the optimization logic fails entirely for meshes that have less than 5 or 8 elements and raises error.

- Fix `MeshTri1.element_finder` and `MeshTet1.element_finder` for meshes that have a small number of elements.

Moreover, as pointed out in #646, points outside of the mesh are not detected correctly.

- Raise error if the point is outside of the mesh. Fixes #646.