### PR TITLE
In mesh tri 1, remove duplicate indices but keep order.

### DIFF
--- a/docs/examples/ex28.py
+++ b/docs/examples/ex28.py
@@ -88,7 +88,7 @@ import numpy as np
 import pygmsh
 
 
-if version.parse(pygmsh.__version__) < version.parse('7.0.0'):
+if hasattr(pygmsh, '__version__') and version.parse(pygmsh.__version__) < version.parse('7.0.0'):
     class NullContextManager():
         def __enter__(self):
             return None
@@ -111,7 +111,7 @@ def make_mesh(halfheight: float,  # mm
               length: float,
               thickness: float) -> MeshTri:
     with geometrycontext as g:
-        if version.parse(pygmsh.__version__) < version.parse('7.0.0'):
+        if hasattr(pygmsh, '__version__') and version.parse(pygmsh.__version__) < version.parse('7.0.0'):
             geom = pygmsh.built_in.Geometry()
             geom.add_curve_loop = geom.add_line_loop
         else:
@@ -155,7 +155,7 @@ def make_mesh(halfheight: float,  # mm
         geom.add_physical(geom.add_plane_surface(geom.add_curve_loop(
             [*lines[-3:], -lines[1]])), 'solid')
 
-        if version.parse(pygmsh.__version__) < version.parse('7.0.0'):
+        if hasattr(pygmsh.__version__) and version.parse(pygmsh.__version__) < version.parse('7.0.0'):
             return from_meshio(pygmsh.generate_mesh(geom, dim=2))
         else:
             return from_meshio(geom.generate_mesh(dim=2))

--- a/skfem/mesh/mesh_tri_1.py
+++ b/skfem/mesh/mesh_tri_1.py
@@ -328,13 +328,23 @@ class MeshTri1(Mesh2D):
         tree = cKDTree(np.mean(self.p[:, self.t], axis=1).T)
 
         def finder(x, y):
-            ix = tree.query(np.array([x, y]).T, 5)[1].flatten()
+            # the 5 nearest neighbours
+            ind = tree.query(np.array([x, y]).T, 5)[1]
+            ix = ind.flatten()
+
+            # drop duplicates keeping order
+            _, ix_ind = np.unique(ix, return_index=True)
+            ix = ix[np.sort(ix_ind)]
+
             X = mapping.invF(np.array([x, y])[:, None], ix)
+
+            # inside.shape = (x.shape[0] * 5, x.shape[0])
             inside = (
                 (X[0] >= 0) *
                 (X[1] >= 0) *
                 (1 - X[0] - X[1] >= 0)
             )
-            return np.array([ix[np.argmax(inside, axis=0)]]).flatten()
+            out = np.argmax(inside, axis=0)
+            return np.array([ix[out]]).flatten()
 
         return finder


### PR DESCRIPTION
Putting this here to try to run the tests again. I think they were failing for unrelated reasons. 

Might simply be absorbable into #667 rather than clash with it.