### PR TITLE
atleast_2d before super-post-init

### DIFF
--- a/skfem/mesh/mesh_line_1.py
+++ b/skfem/mesh/mesh_line_1.py
@@ -20,11 +20,8 @@ class MeshLine1(Mesh):
 
     def __post_init__(self):
 
+        self.doflocs = np.atleast_2d(self.doflocs)
         super().__post_init__()
-
-        if self.doflocs.ndim == 1:
-            # support flat arrays
-            self.doflocs = np.array([self.doflocs])
 
         if self.t.shape[1] != self.doflocs.shape[1] - 1:
             # fill self.t assuming ascending self.doflocs if not provided

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -222,24 +222,32 @@ def test_interpolator_probes(mtype, e, nrefs, npoints):
 
 
 @pytest.mark.parametrize(
-    "mtype,e1,e2",
+    "mtype,e1,e2,flat",
     [
-        (MeshTri, ElementTriP1(), ElementTriP0()),
-        (MeshTri, ElementTriP1(), ElementTriP1()),
-        (MeshTri, ElementTriP2(), ElementTriP1()),
-        (MeshTri, ElementTriP2(), ElementTriP2()),
-        (MeshTri, ElementTriP2(), None),
-        (MeshQuad, ElementQuad1(), ElementQuad0()),
-        (MeshQuad, ElementQuad1(), ElementQuad1()),
-        (MeshQuad, ElementQuad2(), ElementQuad2()),
-        (MeshTet, ElementTetP1(), ElementTetP0()),
-        (MeshTet, ElementTetP2(), ElementTetP2()),
-        (MeshHex, ElementHex1(), ElementHex0()),
-        (MeshHex, ElementHex1(), ElementHex1()),
-        (MeshHex, ElementHex2(), ElementHex2()),
-    ]
+        (MeshTri, ElementTriP1(), ElementTriP0(), False),
+        (MeshTri, ElementTriP1(), ElementTriP1(), False),
+        (MeshTri, ElementTriP2(), ElementTriP1(), False),
+        (MeshTri, ElementTriP2(), ElementTriP2(), False),
+        (MeshTri, ElementTriP1(), ElementTriP0(), True),
+        (MeshTri, ElementTriP1(), ElementTriP1(), True),
+        (MeshTri, ElementTriP2(), ElementTriP1(), True),
+        (MeshTri, ElementTriP2(), ElementTriP2(), True),
+        (MeshTri, ElementTriP2(), None, False),
+        (MeshTri, ElementTriP2(), None, True),
+        (MeshQuad, ElementQuad1(), ElementQuad0(), False),
+        (MeshQuad, ElementQuad1(), ElementQuad1(), False),
+        (MeshQuad, ElementQuad2(), ElementQuad2(), False),
+        (MeshQuad, ElementQuad1(), ElementQuad0(), True),
+        (MeshQuad, ElementQuad1(), ElementQuad1(), True),
+        (MeshQuad, ElementQuad2(), ElementQuad2(), True),
+        (MeshTet, ElementTetP1(), ElementTetP0(), False),
+        (MeshTet, ElementTetP2(), ElementTetP2(), False),
+        (MeshHex, ElementHex1(), ElementHex0(), False),
+        (MeshHex, ElementHex1(), ElementHex1(), False),
+        (MeshHex, ElementHex2(), ElementHex2(), False),
+    ],
 )
-def test_trace(mtype, e1, e2):
+def test_trace(mtype, e1, e2, flat):
 
     m = mtype().refined(3)
 
@@ -247,7 +255,9 @@ def test_trace(mtype, e1, e2):
     basis = FacetBasis(m, e1,
                        facets=m.facets_satisfying(lambda x: x[x.shape[0] - 1] == 0.0))
     xfun = projection(lambda x: x[0], CellBasis(m, e1))
-    nbasis, y = basis.trace(xfun, lambda p: p[0:(p.shape[0] - 1)], target_elem=e2)
+    nbasis, y = basis.trace(
+        xfun, lambda p: p[0] if flat else p[0 : (p.shape[0] - 1)], target_elem=e2
+    )
 
     @Functional
     def integ(w):

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -255,9 +255,7 @@ def test_trace(mtype, e1, e2, flat):
     basis = FacetBasis(m, e1,
                        facets=m.facets_satisfying(lambda x: x[x.shape[0] - 1] == 0.0))
     xfun = projection(lambda x: x[0], CellBasis(m, e1))
-    nbasis, y = basis.trace(
-        xfun, lambda p: p[0] if flat else p[0 : (p.shape[0] - 1)], target_elem=e2
-    )
+    nbasis, y = basis.trace(xfun, lambda p: p[0] if flat else p[:-1], target_elem=e2)
 
     @Functional
     def integ(w):

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -252,8 +252,7 @@ def test_trace(mtype, e1, e2, flat):
     m = mtype().refined(3)
 
     # use the boundary where last coordinate is zero
-    basis = FacetBasis(m, e1,
-                       facets=m.facets_satisfying(lambda x: x[x.shape[0] - 1] == 0.0))
+    basis = FacetBasis(m, e1, facets=m.facets_satisfying(lambda x: x[-1] == 0.0))
     xfun = projection(lambda x: x[0], CellBasis(m, e1))
     nbasis, y = basis.trace(xfun, lambda p: p[0] if flat else p[:-1], target_elem=e2)
 


### PR DESCRIPTION
Coercion of &lsquo;scalar&rsquo; one-dimensional coordinates to 1-vectors needs to happen before `Mesh.__post_init__`; otherwise the trace of a two-dimensional basis with a &lsquo;scalar&rsquo; one-dimensional `projection` hits #686.