### PR TITLE
ignore cell_sets "gmsh:*" inserted by meshio

### DIFF
--- a/skfem/io/meshio.py
+++ b/skfem/io/meshio.py
@@ -90,10 +90,11 @@ def from_meshio(m,
 
     # parse boundaries from cell_sets
     if m.cell_sets and bnd_type in m.cells_dict:
-        facets = {k: [tuple(f) for f in
-                      np.sort(m.cells_dict[bnd_type][v[bnd_type]])]
-                  for k, v in m.cell_sets_dict.items()
-                  if bnd_type in v}
+        facets = {
+            k: [tuple(f) for f in np.sort(m.cells_dict[bnd_type][v[bnd_type]])]
+            for k, v in m.cell_sets_dict.items()
+            if bnd_type in v and k.split(":")[0] != "gmsh"
+        }
         boundaries = {k: np.array([i for i, f in
                                    enumerate(map(tuple, mtmp.facets.T))
                                    if f in v])


### PR DESCRIPTION
Fixes #691.  It or something like it is required to be able to read a valid MSH 4.1 generated by Gmsh, e.g. the backward-facing step of exx 24, 27; `meshio.read` inserts a cell-set called `"gmsh:bounding-entities"` which contains invalid cell-indices, causing our `skfem.io.meshio.from_meshio` to raise an `IndexError` in attempting to parse it as a boundary.

This cherry-picks ff83c84 from #693 which had expanded beyond its bounds, as discussed there.
