### PR TITLE
modify ex36 and test to check the deformed volume and the residual

### DIFF
--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -305,11 +305,14 @@ class TestEx35(TestCase):
 class TestEx36(TestCase):
 
     def runTest(self):
-        from docs.examples.ex36 import du, dp
+        from docs.examples.ex36 import du, dp, volume_deformed, norm_res
         self.assertAlmostEqual(np.linalg.norm(du),
-                               16.529402115680444,
+                               16.530715141106377,
                                delta=1e-5)
         self.assertAlmostEqual(dp[0], -0.5, delta=1.e-8)
+        self.assertAlmostEqual(volume_deformed, 1., delta=1.e-4)
+        self.assertAlmostEqual(norm_res, 0., delta=1.e-8)
+
 
 
 class TestEx37(TestCase):


### PR DESCRIPTION
Small changes to ex36 some of which were discussed in #730 

1. Increased the bulk modulus to 10^4 times shear modulus (to make it more incompressible)

2. One thing that was missing as well was a check for the actual residual norm. I was checking the norms of `du` and `dp` but not `f[I]` which is what should be checked in the first place -- since that is what we are solving.

3. Changed the tests accordingly.

Let me know once you get time to take a look

Thanks