### PR TITLE
DOC: ChangeLog entry for #695

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ with respect to documented and/or tested features.
   meshes
 - Added: `ElementTriP1DG`, `ElementQuad1DG`, `ElementHex1DG`,
   `ElementLineP1DG`; shorthands for `ElementTriDG(ElementTriP1())` etc.
+- Fixed: `Mesh.load` ignores unparseable `cell_sets` inserted by `meshio` in MSH 4.1
 - Fixed: `MappingIsoparametric` is now about 2x faster for large meshes thanks
   to additional caching
 - Fixed: `MeshHex2.save` did not work properly


### PR DESCRIPTION
The bug-fix in #695 that allows `skfem.Mesh.load` to load subdomains or boundaries from MSH 4.1 generated by Gmsh by ignoring the ill-formed `"gmsh:bounding_entities"` `cell_set` inserted by `meshio` for its own internal purposes is yet to be released, having been merged 2021-08-20 while the latest release was [3.2.0](https://github.com/kinnala/scikit-fem/releases/tag/3.2.0) on 08-03.

I think #695 was merged as part of the much more extensive mesh improvments #692 that might under SemVer necessitate bumping the major version to 4?  Were there other issues to be resolved before scikit-fem 4?  It'd be good to get #695 released as 3.2.0 can't read boundaries from MSH 4.1, the default format generated by Gmsh.

I also noticed when tracking down why an industrial scikit-fem script depending on reading Gmsh (which had worked when Gmsh wrote MSH 2.2 by default and still after that with MSH 4.1 but before meshio started inserting `"gmsh:bounding_entities"`) worked on master but not the latest release that I had forgotten to note #695 in the ChangeLog.  This PR is that missing entry.