### PR TITLE
Add wedge 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,21 +257,23 @@ with respect to documented and/or tested features.
   have multiple element types written in the same file, one element type at
   a time
 - Added: `asm` will now accept a list of bases, assemble the same form using
-  all of the bases and sum the result (useful for jump terms and mixed meshes)
+  all of the bases and sum the result (useful for jump terms and mixed meshes, see Example 41)
 - Added: `Mesh.with_boundaries` now allows the definition of internal boundaries/interfaces
   via the flag `boundaries_only=False`
 - Added: `MeshTri1DG`, `MeshQuad1DG`, `MeshHex1DG`, `MeshLine1DG`; new mesh
   types for describing meshes with a discontinuous topology, e.g., periodic
-  meshes
+  meshes (see Example 42)
 - Added: `ElementHexDG` for transforming hexahedral H1 elements to DG/L2 elements.
 - Added: `ElementTriP1DG`, `ElementQuad1DG`, `ElementHex1DG`,
   `ElementLineP1DG`; shorthands for `ElementTriDG(ElementTriP1())` etc.
 - Added: `ElementTriSkeletonP0` and `ElementTriSkeletonP1` for defining
-  Lagrange multipliers on the skeleton mesh
+  Lagrange multipliers on the skeleton mesh (see Example 40)
 - Added: `TrilinearForm` for assembling a sparse 3-tensor, e.g., when dealing
   with unknown material data
 - Added: `MeshTri.oriented` for CCW oriented triangular meshes which can be
   useful for debugging or interfacing to external tools
+- Added: partial support for `MeshWedge1` and `ElementWedge1`, the lowest order
+  wedge mesh and element
 - Fixed: `MappingIsoparametric` is now about 2x faster for large meshes thanks
   to additional caching
 - Fixed: `MeshHex2.save` did not work properly

--- a/skfem/element/__init__.py
+++ b/skfem/element/__init__.py
@@ -31,6 +31,7 @@ from .element_hex import (ElementHex0, ElementHex1, ElementHex2,  # noqa
 from .element_line import (ElementLineP0, ElementLineP1, ElementLineP2,  # noqa
                            ElementLinePp, ElementLineHermite,
                            ElementLineMini, ElementLineP1DG)
+from .element_wedge_1 import ElementWedge1
 from .element_composite import ElementComposite  # noqa
 
 
@@ -106,4 +107,5 @@ __all__ = [
     "ElementLinePp",
     "ElementLineHermite",
     "ElementLineMini",
+    "ElementWedge1",
 ]

--- a/skfem/element/element_wedge_1.py
+++ b/skfem/element/element_wedge_1.py
@@ -1,3 +1,9 @@
+import numpy as np
+
+from .element_h1 import ElementH1
+from ..refdom import RefWedge
+
+
 class ElementWedge1(ElementH1):
 
     nodal_dofs = 1
@@ -6,8 +12,8 @@ class ElementWedge1(ElementH1):
     doflocs = np.array([[0., 0., 0.],
                         [1., 0., 0.],
                         [0., 1., 0.],
-                        [0., 0., 1.]
-                        [1., 0., 1.]
+                        [0., 0., 1.],
+                        [1., 0., 1.],
                         [0., 1., 1.]])
     refdom = RefWedge
 

--- a/skfem/element/element_wedge_1.py
+++ b/skfem/element/element_wedge_1.py
@@ -1,0 +1,62 @@
+class ElementWedge1(ElementH1):
+
+    nodal_dofs = 1
+    maxdeg = 2
+    dofnames = ['u']
+    doflocs = np.array([[0., 0., 0.],
+                        [1., 0., 0.],
+                        [0., 1., 0.],
+                        [0., 0., 1.]
+                        [1., 0., 1.]
+                        [0., 1., 1.]])
+    refdom = RefWedge
+
+    def lbasis(self, X, i):
+        x, y, z = X
+
+        if i == 0:
+            phi = (1. - x - y) * (1. - z)
+            dphi = np.array([
+                z - 1.,
+                z - 1.,
+                x + y - 1.,
+            ])
+        elif i == 1:
+            phi = x * (1. - z)
+            dphi = np.array([
+                1. - z,
+                0. * x,
+                -x,
+            ])
+        elif i == 2:
+            phi = y * (1. - z)
+            dphi = np.array([
+                0. * x,
+                1. - z,
+                -y,
+            ])
+        elif i == 3:
+            phi = (1. - x - y) * z
+            dphi = np.array([
+                -z,
+                -z,
+                1. - x - y,
+            ])
+        elif i == 4:
+            phi = x * z
+            dphi = np.array([
+                z,
+                0. * x,
+                x,
+            ])
+        elif i == 5:
+            phi = y * z
+            dphi = np.array([
+                0. * x,
+                z,
+                y,
+            ])
+        else:
+            self._index_error()
+
+        return phi, dphi

--- a/skfem/io/meshio.py
+++ b/skfem/io/meshio.py
@@ -7,14 +7,15 @@ import skfem
 
 MESH_TYPE_MAPPING = {
     'tetra': skfem.MeshTet1,
-    'hexahedron': skfem.MeshHex1,
-    'triangle': skfem.MeshTri1,
-    'quad': skfem.MeshQuad1,
-    'line': skfem.MeshLine1,
     'tetra10': skfem.MeshTet2,
-    'triangle6': skfem.MeshTri2,
-    'quad9': skfem.MeshQuad2,
+    'hexahedron': skfem.MeshHex1,
     'hexahedron27': skfem.MeshHex2,
+    'wedge': skfem.MeshWedge1,
+    'triangle': skfem.MeshTri1,
+    'triangle6': skfem.MeshTri2,
+    'quad': skfem.MeshQuad1,
+    'quad9': skfem.MeshQuad2,
+    'line': skfem.MeshLine1,
 }
 
 BOUNDARY_TYPE_MAPPING = {
@@ -52,14 +53,21 @@ def from_meshio(m,
     if force_meshio_type is None:
         # detect 3D
         for k in cells:
-            if k in {'tetra', 'hexahedron', 'tetra10', 'hexahedron27'}:
+            if k in {'tetra',
+                     'hexahedron',
+                     'tetra10',
+                     'hexahedron27',
+                     'wedge'}:
                 meshio_type = k
                 break
 
         if meshio_type is None:
             # detect 2D
             for k in cells:
-                if k in {'triangle', 'quad', 'triangle6', 'quad9'}:
+                if k in {'triangle',
+                         'quad',
+                         'triangle6',
+                         'quad9'}:
                     meshio_type = k
                     break
 

--- a/skfem/mapping/mapping_isoparametric.py
+++ b/skfem/mapping/mapping_isoparametric.py
@@ -202,27 +202,7 @@ class MappingIsoparametric(Mapping):
         return invDF / detDF
 
     def normals(self, X, tind, find, t2f):
-        if self.dim == 1:
-            Nref = np.array([[-1.],
-                             [1.]])
-        elif self.dim == 2 and self.mesh.t2f.shape[0] == 3:
-            Nref = np.array([[0., -1.],
-                             [1., 1.],
-                             [-1., 0.]])
-        elif self.dim == 2 and self.mesh.t2f.shape[0] == 4:
-            Nref = np.array([[0., -1.],
-                             [1., 0.],
-                             [0., 1.],
-                             [-1., 0.]])
-        elif self.dim == 3:
-            Nref = np.array([[1., 0., 0.],
-                             [0., 0., 1.],
-                             [0., 1., 0.],
-                             [0., -1., 0.],
-                             [0., 0., -1.],
-                             [-1., 0., 0.]])
-        else:
-            raise Exception("Not implemented for the given dimension.")
+        Nref = self.mesh.elem.refdom.normals
 
         invDF = self.invDF(X, tind)
         N = np.empty((self.dim, len(find)))

--- a/skfem/mesh/__init__.py
+++ b/skfem/mesh/__init__.py
@@ -41,6 +41,7 @@ from .mesh_tri_1_dg import MeshTri1DG
 from .mesh_quad_1_dg import MeshQuad1DG
 from .mesh_hex_1_dg import MeshHex1DG
 from .mesh_line_1_dg import MeshLine1DG
+from .mesh_wedge_1 import MeshWedge1
 
 # aliases
 MeshTri = MeshTri1
@@ -95,4 +96,5 @@ __all__ = [
     "MeshHex1",
     "MeshHex2",
     "MeshHex1DG",
+    "MeshWedge1",
 ]

--- a/skfem/mesh/mesh.py
+++ b/skfem/mesh/mesh.py
@@ -679,6 +679,8 @@ class Mesh:
     @staticmethod
     def build_entities(t, indices, sort=True):
         """Build low dimensional topological entities."""
+        if indices is None:
+            return None, None
         indexing = np.hstack(tuple([t[ix] for ix in indices]))
         sorted_indexing = np.sort(indexing, axis=0)
 

--- a/skfem/mesh/mesh_line_1.py
+++ b/skfem/mesh/mesh_line_1.py
@@ -19,7 +19,13 @@ class MeshLine1(Mesh):
     affine: bool = True
 
     def __mul__(self, other):
-        return MeshQuad1.init_tensor(self.p[0], other.p[0])
+
+        from .mesh_line_1 import MeshLine1
+
+        if isinstance(other, MeshLine1):
+            return MeshQuad1.init_tensor(self.p[0], other.p[0])
+
+        return other * self
 
     def _uniform(self):
         p, t = self.doflocs, self.t

--- a/skfem/mesh/mesh_tri_1.py
+++ b/skfem/mesh/mesh_tri_1.py
@@ -342,6 +342,34 @@ class MeshTri1(Mesh2D):
             sort_t=False,
         )
 
+    def __mul__(self, other):
+
+        from .mesh_wedge_1 import MeshWedge1
+        from .mesh_line_1 import MeshLine1
+
+        if isinstance(other, MeshLine1):
+            points = np.zeros((3, 0), dtype=np.float64)
+            wedges = np.zeros((6, 0), dtype=np.int64)
+            diff = 0
+            for i, p in enumerate(np.sort(other.p[0])):
+                points = np.hstack((
+                    points,
+                    np.vstack((self.p,
+                               np.array(self.p.shape[1] * [p])))
+                ))
+                if i == len(other.p[0]) - 1:
+                    pass
+                else:
+                    wedges = np.hstack((
+                        wedges,
+                        np.vstack((self.t + diff,
+                                   self.t + self.nvertices + diff))
+                    ))
+                diff += self.nvertices
+            return MeshWedge1(points, wedges)
+
+        raise NotImplementedError
+
     def element_finder(self, mapping=None):
 
         if mapping is None:

--- a/skfem/mesh/mesh_wedge_1.py
+++ b/skfem/mesh/mesh_wedge_1.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Type
 
 import numpy as np
@@ -28,8 +28,8 @@ class MeshWedge1(Mesh3D):
 
         t = np.hstack((
             self.t[[0, 1, 2, 3]],
-            self.t[[3, 4, 5, 0]],
-            self.t[[0, 3, 2, 4]],
+            self.t[[1, 2, 3, 4]],
+            self.t[[2, 3, 4, 5]],
         ))
 
         return MeshTet1(self.doflocs, t)

--- a/skfem/mesh/mesh_wedge_1.py
+++ b/skfem/mesh/mesh_wedge_1.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from typing import Type
 
 import numpy as np

--- a/skfem/mesh/mesh_wedge_1.py
+++ b/skfem/mesh/mesh_wedge_1.py
@@ -1,0 +1,44 @@
+from dataclasses import dataclass, replace
+from typing import Type
+
+import numpy as np
+from numpy import ndarray
+
+from ..element import Element, ElementWedge1
+from .mesh_3d import Mesh3D
+from .mesh_tet_1 import MeshTet1
+
+
+@dataclass(repr=False)
+class MeshWedge1(Mesh3D):
+
+    doflocs: ndarray = np.array([[0., 0., 0.],
+                                 [0., 0., 1.],
+                                 [0., 1., 0.],
+                                 [1., 0., 0.],
+                                 [0., 1., 1.],
+                                 [1., 0., 1.],
+                                 [1., 1., 0.],
+                                 [1., 1., 1.]], dtype=np.float64).T
+    t: ndarray = np.array([[0, 2, 3, 1, 4, 5],
+                           [2, 3, 6, 4, 5, 7]], dtype=np.int64).T
+    elem: Type[Element] = ElementWedge1
+
+    def to_meshtet(self):
+
+        t = np.hstack((
+            self.t[[0, 1, 2, 3]],
+            self.t[[3, 4, 5, 0]],
+            self.t[[0, 3, 2, 4]],
+        ))
+
+        return MeshTet1(self.doflocs, t)
+
+    def element_finder(self, mapping=None):
+        """Transform to :class:`skfem.MeshTet` and return its finder."""
+        tet_finder = self.to_meshtet().element_finder()
+
+        def finder(*args):
+            return tet_finder(*args) % self.t.shape[1]
+
+        return finder

--- a/skfem/quadrature.py
+++ b/skfem/quadrature.py
@@ -4,7 +4,8 @@ from typing import Tuple, Type
 
 import numpy as np
 from numpy.polynomial.legendre import leggauss
-from .refdom import Refdom, RefPoint, RefLine, RefTri, RefQuad, RefTet, RefHex
+from .refdom import (Refdom, RefPoint, RefLine, RefTri, RefQuad, RefTet,
+                     RefHex, RefWedge)
 
 
 def get_quadrature(refdom: Type[Refdom],
@@ -35,6 +36,17 @@ def get_quadrature(refdom: Type[Refdom],
         return get_quadrature_line(norder)
     elif refdom == RefPoint:
         return get_quadrature_point(norder)
+    elif refdom == RefWedge:
+        X1, W1 = get_quadrature_line(norder)
+        X2, W2 = get_quadrature_tri(norder)
+        A, B, C = np.meshgrid(X1, X2[:1], X2[1:])
+        Y = np.vstack((A.flatten(order="F"),
+                       B.flatten(order="F"),
+                       C.flatten(order="F")))
+        A, B, C = np.meshgrid(W1, W2, W2)
+        Z = A * B * C
+        W = Z.flatten(order="F")
+        return Y, W
     elif refdom == RefQuad:
         X, W = get_quadrature_line(norder)
         # generate tensor product rule from 1D rule

--- a/skfem/quadrature.py
+++ b/skfem/quadrature.py
@@ -68,7 +68,8 @@ def get_quadrature(refdom: Type[Refdom],
         W = Z.flatten(order="F")
         return Y, W
     else:
-        raise NotImplementedError("The given mesh type is not supported!")
+        raise NotImplementedError("The given reference domain type '{}' "
+                                  "is not supported!".format(refdom))
 
 
 def get_quadrature_tet(norder: int) -> Tuple[np.ndarray, np.ndarray]:

--- a/skfem/refdom.py
+++ b/skfem/refdom.py
@@ -42,6 +42,8 @@ class RefLine(Refdom):
 
     p = np.array([[0., 1.]], dtype=np.float64)
     t = np.array([[0], [1]], dtype=np.int64)
+    normals = np.array([[-1.],
+                        [1.]])
     facets = [[0],
               [1]]
     brefdom = RefPoint
@@ -55,6 +57,9 @@ class RefTri(Refdom):
     p = np.array([[0., 1., 0.],
                   [0., 0., 1.]], dtype=np.float64)
     t = np.array([[0], [1], [2]], dtype=np.int64)
+    normals = np.array([[0., -1.],
+                        [1., 1.],
+                        [-1., 0.]])
     facets = [[0, 1],
               [1, 2],
               [0, 2]]
@@ -111,6 +116,10 @@ class RefQuad(Refdom):
     p = np.array([[0., 1., 1., 0.],
                   [0., 0., 1., 1.]], dtype=np.float64)
     t = np.array([[0], [1], [2], [3]], dtype=np.int64)
+    normals = np.array([[0., -1.],
+                        [1., 0.],
+                        [0., 1.],
+                        [-1., 0.]])
     facets = [[0, 1],
               [1, 2],
               [2, 3],
@@ -132,6 +141,12 @@ class RefHex(Refdom):
                   [0., 0., 1.],
                   [0., 0., 0.]], dtype=np.float64).T
     t = np.array([[0], [1], [2], [3], [4], [5], [6], [7]], dtype=np.int64)
+    normals = np.array([[1., 0., 0.],
+                        [0., 0., 1.],
+                        [0., 1., 0.],
+                        [0., -1., 0.],
+                        [0., 0., -1.],
+                        [-1., 0., 0.]])
     facets = [[0, 1, 4, 2],
               [0, 2, 6, 3],
               [0, 3, 5, 1],
@@ -166,6 +181,11 @@ class RefWedge(Refdom):
                   [1., 0., 1.],
                   [0., 1., 1.]], dtype=np.float64).T
     t = np.array([[0], [1], [2], [3], [4], [5]], dtype=np.int64)
+    normals = np.array([[0., -1., 0.],
+                        [1., 1., 0.],
+                        [-1., 0., 0.],
+                        [0., 0., -1.],
+                        [0., 0., 1.]])
     facets = [[0, 1, 4, 3],
               [1, 2, 5, 4],
               [0, 2, 5, 3],

--- a/skfem/refdom.py
+++ b/skfem/refdom.py
@@ -166,10 +166,22 @@ class RefWedge(Refdom):
                   [1., 0., 1.],
                   [0., 1., 1.]], dtype=np.float64).T
     t = np.array([[0], [1], [2], [3], [4], [5]], dtype=np.int64)
-    facets = None
-    edges = None
+    facets = [[0, 1, 4, 3],
+              [1, 2, 5, 4],
+              [0, 2, 5, 3],
+              [0, 1, 2, 0],  # last index repeated
+              [3, 4, 5, 3]]  # last index repeated
+    edges = [[0, 1],
+             [1, 2],
+             [0, 2],
+             [3, 4],
+             [4, 5],
+             [3, 5],
+             [0, 3],
+             [1, 4],
+             [2, 5]]
     brefdom = None
     nnodes = 6
-    nfacets = 0
-    nedges = 0
+    nfacets = 5
+    nedges = 9
     name = "Wedge"

--- a/skfem/refdom.py
+++ b/skfem/refdom.py
@@ -11,6 +11,7 @@ class Refdom:
     p: ndarray
     t: ndarray
     facets: Optional[List[List[int]]] = None
+    edges: Optional[List[List[int]]] = None
     brefdom: Optional[Type] = None
     nnodes: int = 0
     nfacets: int = 0
@@ -154,3 +155,21 @@ class RefHex(Refdom):
     nfacets = 6
     nedges = 12
     name = "Hexahedral"
+
+
+class RefWedge(Refdom):
+
+    p = np.array([[0., 0., 0.],
+                  [1., 0., 0.],
+                  [0., 1., 0.],
+                  [0., 0., 1.],
+                  [1., 0., 1.],
+                  [0., 1., 1.]], dtype=np.float64).T
+    t = np.array([[0], [1], [2], [3], [4], [5]], dtype=np.int64)
+    facets = None
+    edges = None
+    brefdom = None
+    nnodes = 6
+    nfacets = 0
+    nedges = 0
+    name = "Wedge"

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -208,23 +208,24 @@ class TestIncompatibleMeshElement(TestCase):
         (MeshQuad, ElementQuad1(), 1, 10),
         (MeshQuad, ElementQuad1(), 1, 3e5),
         (MeshHex, ElementHex1(), 1, 1e5),
-        (MeshWedge1, ElementWedge1(), 5, 10),
+        (MeshWedge1, ElementWedge1(), 0, 10),
     ]
 )
 def test_interpolator_probes(mtype, e, nrefs, npoints):
 
-    m = mtype().refined(nrefs)
+    m = mtype()
+    if nrefs > 0:
+        m = m.refined(nrefs)
 
     np.random.seed(0)
     X = np.random.rand(m.p.shape[0], int(npoints))
 
     basis = CellBasis(m, e)
 
-    y = projection(lambda x: x[0] ** 2, basis)
+    y = projection(lambda x: x[0] + x[1], basis)
 
     assert_allclose(basis.probes(X) @ y, basis.interpolator(y)(X))
-    atol = 1e-1 if nrefs <= 1 else 1e-3
-    assert_allclose(basis.probes(X) @ y, X[0] ** 2, atol=atol)
+    assert_allclose(basis.probes(X) @ y, X[0] + X[1])
 
 
 @pytest.mark.parametrize(

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -5,14 +5,16 @@ import numpy as np
 from numpy.testing import assert_allclose, assert_almost_equal
 
 from skfem import BilinearForm, asm, solve, condense, projection
-from skfem.mesh import MeshTri, MeshTet, MeshHex, MeshQuad, MeshLine1
+from skfem.mesh import (MeshTri, MeshTet, MeshHex,
+                        MeshQuad, MeshLine1, MeshWedge1)
 from skfem.assembly import CellBasis, FacetBasis, Dofs, Functional
 from skfem.element import (ElementVectorH1, ElementTriP2, ElementTriP1,
                            ElementTetP2, ElementHexS2, ElementHex2,
                            ElementQuad2, ElementLineP2, ElementTriP0,
                            ElementLineP0, ElementQuad1, ElementQuad0,
                            ElementTetP1, ElementTetP0, ElementHex1,
-                           ElementHex0, ElementLineP1, ElementLineMini)
+                           ElementHex0, ElementLineP1, ElementLineMini,
+                           ElementWedge1)
 
 
 class TestCompositeSplitting(TestCase):
@@ -126,8 +128,11 @@ class TestInterpolatorTet(TestCase):
     element_type = ElementTetP2
     nrefs = 1
 
+    def prepare_mesh(self):
+        return self.mesh_type().refined(self.nrefs)
+
     def runTest(self):
-        m = self.mesh_type().refined(self.nrefs)
+        m = self.prepare_mesh()
         basis = CellBasis(m, self.element_type())
         x = projection(lambda x: x[0] ** 2, basis)
         fun = basis.interpolator(x)
@@ -198,11 +203,12 @@ class TestIncompatibleMeshElement(TestCase):
         (MeshTri, ElementTriP1(), 5, 10),
         (MeshTri, ElementTriP1(), 1, 3e5),
         (MeshTet, ElementTetP2(), 1, 10),
-        (MeshTet, ElementTetP1(), 5, 10),
-        (MeshTet, ElementTetP1(), 1, 3e5),
+        (MeshTet, ElementTetP1(), 4, 10),
+        (MeshTet, ElementTetP1(), 1, 3e4),
         (MeshQuad, ElementQuad1(), 1, 10),
         (MeshQuad, ElementQuad1(), 1, 3e5),
         (MeshHex, ElementHex1(), 1, 1e5),
+        (MeshWedge1, ElementWedge1(), 5, 10),
     ]
 )
 def test_interpolator_probes(mtype, e, nrefs, npoints):

--- a/tests/test_convergence.py
+++ b/tests/test_convergence.py
@@ -24,9 +24,12 @@ from skfem.element import (
     ElementTriP2,
     ElementTriCR,
     ElementTriHermite,
-    ElementTetCCR)
-from skfem.assembly import FacetBasis, InteriorBasis
-from skfem.mesh import MeshHex, MeshLine, MeshQuad, MeshTet, MeshTri
+    ElementTetCCR,
+    ElementWedge1
+)
+from skfem.assembly import FacetBasis, Basis
+from skfem.mesh import (MeshHex, MeshLine, MeshQuad, MeshTet, MeshTri,
+                        MeshWedge1)
 
 
 class ConvergenceQ1(unittest.TestCase):
@@ -34,6 +37,9 @@ class ConvergenceQ1(unittest.TestCase):
     rateL2 = 2.0
     rateH1 = 1.0
     eps = 0.1
+
+    def do_refined(self, m, itr):
+        return m.refined()
 
     def runTest(self):
 
@@ -60,7 +66,7 @@ class ConvergenceQ1(unittest.TestCase):
 
         for itr in range(Nitrs):
             if itr > 0:
-                m = m.refined()
+                m = self.do_refined(m, itr)
             ib = self.create_basis(m)
 
             A = asm(laplace, ib)
@@ -156,7 +162,7 @@ class ConvergenceQ1(unittest.TestCase):
 
     def create_basis(self, m):
         e = ElementQuad1()
-        return InteriorBasis(m, e)
+        return Basis(m, e)
 
     def setUp(self):
         self.mesh = MeshQuad().refined(2)
@@ -169,7 +175,7 @@ class ConvergenceQ2(ConvergenceQ1):
 
     def create_basis(self, m):
         e = ElementQuad2()
-        return InteriorBasis(m, e)
+        return Basis(m, e)
 
     def setUp(self):
         self.mesh = MeshQuad().refined(2)
@@ -179,14 +185,14 @@ class ConvergenceQuadS2(ConvergenceQ2):
 
     def create_basis(self, m):
         e = ElementQuadS2()
-        return InteriorBasis(m, e)
+        return Basis(m, e)
 
 
 class ConvergenceTriP1(ConvergenceQ1):
 
     def create_basis(self, m):
         e = ElementTriP1()
-        return InteriorBasis(m, e)
+        return Basis(m, e)
 
     def setUp(self):
         self.mesh = MeshTri.init_sqsymmetric().refined(2)
@@ -199,7 +205,7 @@ class ConvergenceTriP2(ConvergenceTriP1):
 
     def create_basis(self, m):
         e = ElementTriP2()
-        return InteriorBasis(m, e)
+        return Basis(m, e)
 
 
 class ConvergenceTriHermite(ConvergenceTriP1):
@@ -210,7 +216,7 @@ class ConvergenceTriHermite(ConvergenceTriP1):
 
     def create_basis(self, m):
         e = ElementTriHermite()
-        return InteriorBasis(m, e)
+        return Basis(m, e)
 
     def get_bc_nodes(self, ib):
         return np.concatenate((
@@ -232,7 +238,7 @@ class ConvergenceTriCR(ConvergenceTriP1):
 
     def create_basis(self, m):
         e = ElementTriCR()
-        return InteriorBasis(m, e)
+        return Basis(m, e)
 
 
 class ConvergenceTriCCR(ConvergenceTriP1):
@@ -242,14 +248,31 @@ class ConvergenceTriCCR(ConvergenceTriP1):
 
     def create_basis(self, m):
         e = ElementTriCCR()
-        return InteriorBasis(m, e)
+        return Basis(m, e)
+
+
+class ConvergenceWedge1(ConvergenceTriP1):
+
+    rateL2 = 1.85
+    rateH1 = 1.0
+
+    def do_refined(self, m, itr):
+        return (MeshLine(np.linspace(0, 1, 2 ** (itr + 2)))
+                * MeshTri().refined(itr + 2))
+
+    def create_basis(self, m):
+        e = ElementWedge1()
+        return Basis(m, e)
+
+    def setUp(self):
+        self.mesh = self.do_refined(None, -1)
 
 
 class ConvergenceTriMini(ConvergenceTriP1):
 
     def create_basis(self, m):
         e = ElementTriMini()
-        return InteriorBasis(m, e)
+        return Basis(m, e)
 
 
 class ConvergenceHex1(ConvergenceQ1):
@@ -260,7 +283,7 @@ class ConvergenceHex1(ConvergenceQ1):
 
     def create_basis(self, m):
         e = ElementHex1()
-        return InteriorBasis(m, e)
+        return Basis(m, e)
 
     def setUp(self):
         self.mesh = MeshHex().refined(2)
@@ -274,7 +297,7 @@ class ConvergenceHexSplitTet1(ConvergenceQ1):
 
     def create_basis(self, m):
         e = ElementTetP1()
-        return InteriorBasis(m, e)
+        return Basis(m, e)
 
     def setUp(self):
         self.mesh = MeshHex().refined(2).to_meshtet()
@@ -288,7 +311,7 @@ class ConvergenceHexS2(ConvergenceQ1):
 
     def create_basis(self, m):
         e = ElementHexS2()
-        return InteriorBasis(m, e)
+        return Basis(m, e)
 
     def setUp(self):
         self.mesh = MeshHex().refined(1)
@@ -301,7 +324,7 @@ class ConvergenceHex2(ConvergenceHexS2):
 
     def create_basis(self, m):
         e = ElementHex2()
-        return InteriorBasis(m, e)
+        return Basis(m, e)
 
 
 class ConvergenceTetP1(ConvergenceQ1):
@@ -312,7 +335,7 @@ class ConvergenceTetP1(ConvergenceQ1):
 
     def create_basis(self, m):
         e = ElementTetP1()
-        return InteriorBasis(m, e)
+        return Basis(m, e)
 
     def setUp(self):
         self.mesh = MeshTet().refined(2)
@@ -325,7 +348,7 @@ class ConvergenceTetCR(ConvergenceTetP1):
 
     def create_basis(self, m):
         e = ElementTetCR()
-        return InteriorBasis(m, e)
+        return Basis(m, e)
 
 
 class ConvergenceTetCCR(ConvergenceTetP1):
@@ -335,7 +358,7 @@ class ConvergenceTetCCR(ConvergenceTetP1):
 
     def create_basis(self, m):
         e = ElementTetCCR()
-        return InteriorBasis(m, e)
+        return Basis(m, e)
 
     def setUp(self):
         self.mesh = MeshTet().refined(1)
@@ -349,7 +372,7 @@ class ConvergenceTetP2(ConvergenceTetP1):
 
     def create_basis(self, m):
         e = ElementTetP2()
-        return InteriorBasis(m, e)
+        return Basis(m, e)
 
     def setUp(self):
         self.mesh = MeshTet().refined(1)
@@ -359,14 +382,14 @@ class ConvergenceTetMini(ConvergenceTetP1):
 
     def create_basis(self, m):
         e = ElementTetMini()
-        return InteriorBasis(m, e, intorder=3)
+        return Basis(m, e, intorder=3)
 
 
 class ConvergenceLineP1(ConvergenceQ1):
 
     def create_basis(self, m):
         e = ElementLineP1()
-        return InteriorBasis(m, e)
+        return Basis(m, e)
 
     def setUp(self):
         self.mesh = MeshLine().refined(3)
@@ -379,7 +402,7 @@ class ConvergenceLineP2(ConvergenceQ1):
 
     def create_basis(self, m):
         e = ElementLineP2()
-        return InteriorBasis(m, e)
+        return Basis(m, e)
 
     def setUp(self):
         self.mesh = MeshLine().refined(3)
@@ -389,7 +412,7 @@ class ConvergenceLineMini(ConvergenceLineP2):
 
     def create_basis(self, m):
         e = ElementLineMini()
-        return InteriorBasis(m, e)
+        return Basis(m, e)
 
 
 class FacetConvergenceTetP2(unittest.TestCase):
@@ -441,7 +464,7 @@ class FacetConvergenceTetP2(unittest.TestCase):
         for itr in range(0, 3):
             m = self.case[0]().refined(self.preref + itr)
 
-            ib = InteriorBasis(m, self.case[1]())
+            ib = Basis(m, self.case[1]())
             fb = FacetBasis(m, self.case[1]())
 
             A = asm(dudv, ib)

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -41,6 +41,7 @@ from skfem.element import (
     ElementQuadDG,
     ElementQuadP,
     ElementHexDG,
+    ElementWedge1,
 )
 from skfem.mesh import MeshHex, MeshLine, MeshQuad, MeshTet, MeshTri
 from skfem.assembly import InteriorBasis, Functional
@@ -78,6 +79,7 @@ class TestNodality(TestCase):
         ElementTetCCR(),
         ElementTriCR(),
         ElementTriCCR(),
+        ElementWedge1(),
     ]
 
     def runTest(self):
@@ -212,6 +214,7 @@ class TestDerivatives(TestCase):
         ElementTriCCR(),
         ElementTetCR(),
         ElementTetCCR(),
+        ElementWedge1(),
     ]
 
     def runTest(self):
@@ -270,6 +273,7 @@ class TestPartitionofUnity(TestCase):
         ElementTetCCR(),
         ElementTriCR(),
         ElementTriCCR(),
+        ElementWedge1(),
     ]
 
     def runTest(self):


### PR DESCRIPTION
Fixes #411. This is second tier support because `FacetBasis` does not work and therefore boundary forms cannot be assembled.
```python

from skfem import *
from skfem.models import laplace, unit_load

mt = MeshTri().refined(3)
ml = MeshLine().refined(3)
m = mt * ml

basis = Basis(m, ElementWedge1())
A = laplace.assemble(basis)
f = unit_load.assemble(basis)

y = solve(*condense(A, f, D=basis.get_dofs()))

m.save('wedg.vtk', point_data={'y': y})
```
In this implementation `MeshWedge1.facets` has duplicates for the triangular facets. This allows `Dofs` and `Basis.get_dofs` to work correctly but some other features simply do not work.

Note: I think `ElementWedge2` can be implemented because it relies only on additional edge dofs and edges work properly here.