### PR TITLE
Make Mesh.draw a simple wrapper to skfem.visuals.vedo

### DIFF
--- a/skfem/io/meshio.py
+++ b/skfem/io/meshio.py
@@ -191,7 +191,9 @@ def from_file(filename, out, **kwargs):
 
 def to_meshio(mesh,
               point_data=None,
-              cell_data=None):
+              cell_data=None,
+              encode_cell_data=True,
+              encode_point_data=False):
 
     t = mesh.dofs.element_dofs.copy()
     if isinstance(mesh, skfem.MeshHex2):
@@ -202,10 +204,15 @@ def to_meshio(mesh,
     mtype = TYPE_MESH_MAPPING[type(mesh)]
     cells = {mtype: t.T}
 
-    if cell_data is None:
-        cell_data = {}
+    if encode_cell_data:
+        if cell_data is None:
+            cell_data = {}
+        cell_data.update(mesh._encode_cell_data())
 
-    cell_data.update(mesh._encode_cell_data())
+    if encode_point_data:
+        if point_data is None:
+            point_data = {}
+        point_data.update(mesh._encode_point_data())
 
     mio = meshio.Mesh(
         mesh.p.T,
@@ -221,10 +228,14 @@ def to_file(mesh,
             filename,
             point_data=None,
             cell_data=None,
+            encode_cell_data=True,
+            encode_point_data=False,
             **kwargs):
 
     meshio.write(filename,
                  to_meshio(mesh,
                            point_data,
-                           cell_data),
+                           cell_data,
+                           encode_cell_data,
+                           encode_point_data),
                  **kwargs)

--- a/skfem/mesh/mesh.py
+++ b/skfem/mesh/mesh.py
@@ -756,16 +756,7 @@ class Mesh:
         """
         raise NotImplementedError
 
-    def plot(self, *args, **kwargs):
-        """Convenience wrapper for :func:`skfem.visuals.matplotlib.plot`."""
-        from skfem.visuals.matplotlib import plot, show
-        ax = plot(self, *args, **kwargs)
-        ax.show = show
-        return ax
-
     def draw(self, *args, **kwargs):
-        """Convenience wrapper for :func:`skfem.visuals.matplotlib.draw`."""
-        from skfem.visuals.matplotlib import draw, show
-        ax = draw(self, *args, **kwargs)
-        ax.show = show
-        return ax
+        """Convenience wrapper for vedo."""
+        from skfem.visuals.vedo import draw
+        return draw(self, *args, **kwargs)

--- a/skfem/mesh/mesh.py
+++ b/skfem/mesh/mesh.py
@@ -185,6 +185,29 @@ class Mesh:
             }
         )
 
+    def _encode_point_data(self) -> Dict[str, List[ndarray]]:
+
+        subdomains = {} if self._subdomains is None else self._subdomains
+        boundaries = {} if self._boundaries is None else self._boundaries
+
+        def indicator(ix):
+            ind = np.zeros(self.nvertices)
+            ind[ix] = 1
+            return ind
+
+        return {
+            **{
+                f"skfem:s:{name}": indicator(np.unique(self.t[:, subdomain]
+                                                       .flatten()))
+                for name, subdomain in subdomains.items()
+            },
+            **{
+                f"skfem:b:{name}": indicator(np.unique(self.facets[:, boundary]
+                                                       .flatten()))
+                for name, boundary in boundaries.items()
+            },
+        }
+
     def _encode_cell_data(self) -> Dict[str, List[ndarray]]:
 
         subdomains = {} if self._subdomains is None else self._subdomains

--- a/skfem/visuals/vedo.py
+++ b/skfem/visuals/vedo.py
@@ -1,10 +1,10 @@
 import tempfile
 
 
-def draw(m, **kwargs):
+def draw(m, backend=False, **kwargs):
     """Visualize meshes."""
     import vedo
-    vedo.embedWindow(False)
+    vedo.embedWindow(backend)
     from vedo import Plotter
     vp = Plotter()
     plot = None

--- a/skfem/visuals/vedo.py
+++ b/skfem/visuals/vedo.py
@@ -3,6 +3,8 @@ import tempfile
 
 def draw(m, **kwargs):
     """Visualize meshes."""
+    import vedo
+    vedo.embedWindow(False)
     from vedo import Plotter
     vp = Plotter()
     plot = None

--- a/skfem/visuals/vedo.py
+++ b/skfem/visuals/vedo.py
@@ -7,9 +7,14 @@ def draw(m, backend=False, **kwargs):
     vedo.embedWindow(backend)
     from vedo import Plotter
     vp = Plotter()
-    plot = None
+    tetmesh = None
     with tempfile.NamedTemporaryFile() as tmp:
-        m.save(tmp.name + '.vtk', **kwargs)
-        plot = vp.load(tmp.name + '.vtk')
-    plot.show = lambda: vp.show([plot])
-    return plot
+        m.save(tmp.name + '.vtk',
+               encode_cell_data=False,
+               encode_point_data=True,
+               **kwargs)
+        tetmesh = vp.load(tmp.name + '.vtk')
+        # save these for further use
+        tetmesh.show = lambda: vp.show([tetmesh]).close()
+        tetmesh.plotter = vp
+    return tetmesh

--- a/skfem/visuals/vedo.py
+++ b/skfem/visuals/vedo.py
@@ -1,10 +1,9 @@
 import tempfile
 
-from vedo import Plotter
-
 
 def draw(m, **kwargs):
     """Visualize meshes."""
+    from vedo import Plotter
     vp = Plotter()
     plot = None
     with tempfile.NamedTemporaryFile() as tmp:

--- a/skfem/visuals/vedo.py
+++ b/skfem/visuals/vedo.py
@@ -1,0 +1,14 @@
+import tempfile
+
+from vedo import Plotter
+
+
+def draw(m, **kwargs):
+    """Visualize meshes."""
+    vp = Plotter()
+    plot = None
+    with tempfile.NamedTemporaryFile() as tmp:
+        m.save(tmp.name + '.vtk', **kwargs)
+        plot = vp.load(tmp.name + '.vtk')
+    plot.show = lambda: vp.show([plot])
+    return plot


### PR DESCRIPTION
Fixes #361.

This is quite cool I think. First `pip install vedo`. Then try
```python
from skfem import *
m = MeshHex().refined(3)
m.draw(point_data={'y': m.p[0]}).show()
```
Then pressing `4` and `l` on the keyboard gives this fancy picture:

![screenshot](https://user-images.githubusercontent.com/973268/134140205-950b1f93-8484-4af9-bc40-31b3bf766a62.png)

Interfacing with vedo is done through a VTK file because the API of vedo is quite complex and this seems to do most of the things that we'd like to do.