### PR TITLE
Eliminates the use of functools.lru_cache to support pickling

### DIFF
--- a/skfem/assembly/basis/abstract_basis.py
+++ b/skfem/assembly/basis/abstract_basis.py
@@ -1,6 +1,5 @@
 import warnings
 from typing import Any, Dict, List, Optional, Tuple, Type, Union
-from functools import lru_cache
 
 import numpy as np
 from numpy import ndarray
@@ -103,7 +102,6 @@ class AbstractBasis:
             return self.get_element_dofs(None)
         return self.get_element_dofs(HashableNdArray(self.tind))
 
-    @lru_cache(maxsize=128)
     def get_element_dofs(self, tind):
         if tind is None:
             return self.dofs.element_dofs

--- a/skfem/mapping/mapping_isoparametric.py
+++ b/skfem/mapping/mapping_isoparametric.py
@@ -6,7 +6,6 @@ from numpy import ndarray
 from skfem.element import Element
 from skfem.mesh import Mesh2D, Mesh3D
 from .mapping import Mapping
-from functools import lru_cache
 from ..generic_utils import HashableNdArray
 
 
@@ -61,7 +60,6 @@ class MappingIsoparametric(Mapping):
                     out += p[i, t[itr, tind]][:, None] * phi
                 return out
 
-        @lru_cache(maxsize=128)
         def J(i, j, X, tind=None):
             if tind is None:
                 out = np.zeros((t.shape[1], X.shape[1]))


### PR DESCRIPTION
This removes the use of `functools.lru_cache` to make objects (dill) pickle-able.  This would close #755.