### PR TITLE
Fix pickle issue with mapping_isoparametric

### DIFF
--- a/skfem/mapping/mapping_isoparametric.py
+++ b/skfem/mapping/mapping_isoparametric.py
@@ -115,26 +115,24 @@ class MappingIsoparametric(Mapping):
         self.dim = p.shape[0]
 
     def __getstate__(self):
-      """
-        Provide a clean state without the memoization on J
+        """Provide a clean state without the memoization on J
         to picklers like pickle or dill
-      """
-      state = self.__dict__.copy()
-      state['J'] = state['J'].__wrapped__
+        """
+        state = self.__dict__.copy()
+        state['J'] = state['J'].__wrapped__
 
-      return state
+        return state
 
     def __setstate__(self, newstate):
-      """
-        Recover the memoization on J when unpickled
-      """
-      # I would like to think there is a cleaner way to do this
-      @lru_cache(maxsize=MappingIsoparametric.cache_size)
-      def Jp(*args, Jo = newstate['J'], **kwargs):
-        return Jo(*args, **kwargs)
-      newstate['J'] = Jp
+        """Recover the memoization on J when unpickled
+        """
+        # I would like to think there is a cleaner way to do this
+        @lru_cache(maxsize=MappingIsoparametric.cache_size)
+        def Jp(*args, Jo = newstate['J'], **kwargs):
+            return Jo(*args, **kwargs)
+        newstate['J'] = Jp
 
-      self.__dict__.update(newstate)
+        self.__dict__.update(newstate)
 
     def G(self, X: ndarray, find: Optional[ndarray] = None) -> ndarray:
         return np.array([self.bndmap(i, X, find=find)


### PR DESCRIPTION
This fixes the issue of pickling `mapping_isoparametric` with some scary introspection by unwrapping the function when marshaling and re-wrapping when recreating the object.  This would close #755.