### PR TITLE
Preliminary work on static condensation and related optimizations

### DIFF
--- a/docs/examples/ex04.py
+++ b/docs/examples/ex04.py
@@ -54,7 +54,7 @@ This is a nonlinear problem since we do not know a priori which subset
 from skfem import *
 from skfem.models.elasticity import (linear_elasticity, lame_parameters,
                                      linear_stress)
-from skfem.helpers import dot, ddot, prod, sym_grad
+from skfem.helpers import dot, ddot, prod, sym_grad, jump
 import numpy as np
 from skfem.io import from_meshio
 from skfem.io.json import from_file, to_file
@@ -110,8 +110,7 @@ limit = 0.3
 @BilinearForm
 def bilin_mortar(u, v, w):
     # jumps
-    ju = (-1.) ** w.idx[0] * dot(u, w.n)
-    jv = (-1.) ** w.idx[1] * dot(v, w.n)
+    ju, jv = jump(w, dot(u, w.n), dot(v, w.n))
     nxn = prod(w.n, w.n)
     mu = .5 * ddot(nxn, C(sym_grad(u)))
     mv = .5 * ddot(nxn, C(sym_grad(v)))
@@ -125,7 +124,7 @@ def gap(x):
 
 @LinearForm
 def lin_mortar(v, w):
-    jv = (-1.) ** w.idx[0] * dot(v, w.n)
+    jv = jump(w, dot(v, w.n))
     mv = .5 * ddot(prod(w.n, w.n), C(sym_grad(v)))
     return ((1. / (alpha * w.h) * gap(w.x) * jv - gap(w.x) * mv)
             * (np.abs(w.x[1]) <= limit))

--- a/docs/examples/ex07.py
+++ b/docs/examples/ex07.py
@@ -1,7 +1,7 @@
 """Discontinuous Galerkin method."""
 
 from skfem import *
-from skfem.helpers import grad, dot
+from skfem.helpers import grad, dot, jump
 from skfem.models.poisson import laplace, unit_load
 
 m = MeshTri.init_sqsymmetric().refined()
@@ -14,8 +14,7 @@ fb = [InteriorFacetBasis(m, e, side=i) for i in [0, 1]]
 
 @BilinearForm
 def dgform(u, v, p):
-    ju = (-1.) ** p.idx[0] * u
-    jv = (-1.) ** p.idx[1] * v
+    ju, jv = jump(p, u, v)
     h = p.h
     n = p.n
     return ju * jv / (alpha * h) - dot(grad(u), n) * jv - dot(grad(v), n) * ju

--- a/docs/examples/ex40.py
+++ b/docs/examples/ex40.py
@@ -31,9 +31,9 @@ def laplace(u, ut, v, vt, w):
 
 @BilinearForm
 def hdg(u, ut, v, vt, w):
-    from skfem.helpers import grad, dot
+    from skfem.helpers import grad, dot, jump
     # outwards normal
-    n = w.n * (-1.) ** w.idx[0]
+    n = jump(w, w.n)
     return dot(n, grad(u)) * (vt - v) + dot(n, grad(v)) * (ut - u)\
         + 1e1 / w.h * (ut - u) * (vt - v)
 

--- a/docs/gettingstarted.rst
+++ b/docs/gettingstarted.rst
@@ -178,5 +178,5 @@ Thus, it makes sense to verify that the error is small.
    ...     uh = w['uh']
    ...     u = np.sin(np.pi * x) * np.sin(np.pi * y) / (2. * np.pi ** 2)
    ...     return (uh - u) ** 2
-   >>> error.assemble(Vh, uh=Vh.interpolate(x))
-   1.069066819861505e-06
+   >>> round(error.assemble(Vh, uh=Vh.interpolate(x)), 9)
+   1.069e-06

--- a/docs/howto.rst
+++ b/docs/howto.rst
@@ -218,10 +218,10 @@ Below we solve explicitly the above variational problem:
    >>> M = fem.BilinearForm(lambda u, v, w: u * v).assemble(basis)
    >>> f = fem.LinearForm(lambda v, w: u_0(w.x) * v).assemble(basis)
    >>> x = fem.solve(*fem.condense(M, f, I=basis.get_dofs()))
-   >>> np.round(x, 5)
-   array([ 0.     ,  0.     ,  1.     ,  0.     ,  0.     , -0.     ,
-           0.     ,  0.     ,  0.61237,  0.15811,  0.61237,  0.15811,
-           0.     ,  0.     ,  0.     ,  0.     ])
+   >>> np.abs(np.round(x, 5))
+   array([0.     , 0.     , 1.     , 0.     , 0.     , 0.     , 0.     ,
+          0.     , 0.61237, 0.15811, 0.61237, 0.15811, 0.     , 0.     ,
+          0.     , 0.     ])
 
 Alternatively, you can use :func:`skfem.utils.projection` which does exactly
 the same thing:
@@ -229,10 +229,10 @@ the same thing:
 .. doctest::
 
    >>> y = fem.projection(u_0, basis, I=basis.get_dofs(), expand=True)
-   >>> np.round(y, 5)
-   array([ 0.     ,  0.     ,  1.     ,  0.     ,  0.     , -0.     ,
-           0.     ,  0.     ,  0.61237,  0.15811,  0.61237,  0.15811,
-           0.     ,  0.     ,  0.     ,  0.     ])
+   >>> np.abs(np.round(y, 5))
+   array([0.     , 0.     , 1.     , 0.     , 0.     , 0.     , 0.     ,
+          0.     , 0.61237, 0.15811, 0.61237, 0.15811, 0.     , 0.     ,
+          0.     , 0.     ])
 
 Assembling jump terms
 =====================

--- a/docs/howto.rst
+++ b/docs/howto.rst
@@ -92,17 +92,17 @@ The previous solution :math:`u_k` must be provided to
    >>> for itr in range(10):  # fixed point iteration
    ...     A = bilinf.assemble(basis, u_k=basis.interpolate(x))
    ...     x = fem.solve(*fem.condense(A, b, I=m.interior_nodes()))
-   ...     print(x.max())
-   0.07278262867647059
-   0.07030433694174187
-   0.07036045457157739
-   0.07035940302769318
-   0.07035942072395032
-   0.07035942044353624
-   0.07035942044783286
-   0.07035942044776827
-   0.07035942044776916
-   0.07035942044776922
+   ...     print(round(x.max(), 10))
+   0.0727826287
+   0.0703043369
+   0.0703604546
+   0.070359403
+   0.0703594207
+   0.0703594204
+   0.0703594204
+   0.0703594204
+   0.0703594204
+   0.0703594204
 
 Inside the form definition, ``w`` is a dictionary of user provided arguments and
 additional default keys.
@@ -210,6 +210,7 @@ Below we solve explicitly the above variational problem:
 
 .. doctest::
 
+   >>> import numpy as np
    >>> import skfem as fem
    >>> m = fem.MeshQuad()
    >>> basis = fem.FacetBasis(m, fem.ElementQuadP(3))
@@ -217,22 +218,21 @@ Below we solve explicitly the above variational problem:
    >>> M = fem.BilinearForm(lambda u, v, w: u * v).assemble(basis)
    >>> f = fem.LinearForm(lambda v, w: u_0(w.x) * v).assemble(basis)
    >>> x = fem.solve(*fem.condense(M, f, I=basis.get_dofs()))
-   >>> x
-   array([ 2.87802132e-16,  1.62145397e-16,  1.00000000e+00,  1.66533454e-16,
-           4.59225774e-16, -4.41713127e-16,  4.63704316e-16,  1.25333771e-16,
-           6.12372436e-01,  1.58113883e-01,  6.12372436e-01,  1.58113883e-01,
-           0.00000000e+00,  0.00000000e+00,  0.00000000e+00,  0.00000000e+00])
+   >>> np.round(x, 5)
+   array([ 0.     ,  0.     ,  1.     ,  0.     ,  0.     , -0.     ,
+           0.     ,  0.     ,  0.61237,  0.15811,  0.61237,  0.15811,
+           0.     ,  0.     ,  0.     ,  0.     ])
 
 Alternatively, you can use :func:`skfem.utils.projection` which does exactly
 the same thing:
 
 .. doctest::
 
-   >>> fem.projection(u_0, basis, I=basis.get_dofs(), expand=True)
-   array([ 2.87802132e-16,  1.62145397e-16,  1.00000000e+00,  1.66533454e-16,
-           4.59225774e-16, -4.41713127e-16,  4.63704316e-16,  1.25333771e-16,
-           6.12372436e-01,  1.58113883e-01,  6.12372436e-01,  1.58113883e-01,
-           0.00000000e+00,  0.00000000e+00,  0.00000000e+00,  0.00000000e+00])
+   >>> y = fem.projection(u_0, basis, I=basis.get_dofs(), expand=True)
+   >>> np.round(y, 5)
+   array([ 0.     ,  0.     ,  1.     ,  0.     ,  0.     , -0.     ,
+           0.     ,  0.     ,  0.61237,  0.15811,  0.61237,  0.15811,
+           0.     ,  0.     ,  0.     ,  0.     ])
 
 Assembling jump terms
 =====================

--- a/skfem/assembly/__init__.py
+++ b/skfem/assembly/__init__.py
@@ -81,7 +81,6 @@ def asm(form: Form,
     nargs = [[arg] if not isinstance(arg, list) else arg for arg in args]
     retval = to(map(lambda a: form.coo_data(*a[1],
                                             idx=a[0],
-                                            maxidx=len(a[1]),
                                             **kwargs),
                     zip(product(*(range(len(x)) for x in nargs)),
                         product(*nargs))))

--- a/skfem/assembly/__init__.py
+++ b/skfem/assembly/__init__.py
@@ -50,10 +50,6 @@ import logging
 from typing import Any
 from itertools import product
 
-from numpy import ndarray
-
-from scipy.sparse import csr_matrix
-
 from .basis import (Basis, CellBasis, FacetBasis, BoundaryFacetBasis,
                     InteriorFacetBasis, MortarFacetBasis)
 from .basis import InteriorBasis, ExteriorFacetBasis  # backwards compatibility

--- a/skfem/assembly/basis/abstract_basis.py
+++ b/skfem/assembly/basis/abstract_basis.py
@@ -210,6 +210,9 @@ class AbstractBasis:
         # loop over solution components
         for c in range(len(refs)):
             ref = refs[c]
+            if ref.is_zero():
+                dfs.append(ref)
+                continue
             fs = []
 
             def linear_combination(n, refn):
@@ -217,6 +220,8 @@ class AbstractBasis:
                 out = 0. * refn.copy()
                 for i in range(self.Nbfun):
                     values = w[self.element_dofs[i]]
+                    if self.basis[i][c].is_zero():
+                        continue
                     out += np.einsum('...,...j->...j', values,
                                      self.basis[i][c][n])
                 return out

--- a/skfem/assembly/form/form.py
+++ b/skfem/assembly/form/form.py
@@ -72,17 +72,8 @@ class Form:
     def dictify(w, basis):
         """Support additional input formats for 'w'."""
         for k in w:
-            if isinstance(w[k], DiscreteField):
-                continue
-            elif isinstance(w[k], tuple):
-                # asm() product index is of type tuple
-                continue
-            elif isinstance(w[k], ndarray) and len(w[k].shape) == 2:
+            if isinstance(w[k], ndarray) and len(w[k].shape) == 2:
                 w[k] = DiscreteField(w[k])
             elif isinstance(w[k], ndarray) and len(w[k].shape) == 1:
                 w[k] = basis.interpolate(w[k])
-            else:
-                raise ValueError("The given type '{}' for the list of extra "
-                                 "form parameters w cannot be converted to "
-                                 "DiscreteField.".format(type(w[k])))
         return w

--- a/skfem/assembly/form/form.py
+++ b/skfem/assembly/form/form.py
@@ -72,8 +72,17 @@ class Form:
     def dictify(w, basis):
         """Support additional input formats for 'w'."""
         for k in w:
-            if isinstance(w[k], ndarray) and len(w[k].shape) == 2:
+            if isinstance(w[k], DiscreteField):
+                continue
+            elif isinstance(w[k], tuple):
+                # asm() product index is of type tuple
+                continue
+            elif isinstance(w[k], ndarray) and len(w[k].shape) == 2:
                 w[k] = DiscreteField(w[k])
             elif isinstance(w[k], ndarray) and len(w[k].shape) == 1:
                 w[k] = basis.interpolate(w[k])
+            else:
+                raise ValueError("The given type '{}' for the list of extra "
+                                 "form parameters w cannot be converted to "
+                                 "DiscreteField.".format(type(w[k])))
         return w

--- a/skfem/element/discrete_field.py
+++ b/skfem/element/discrete_field.py
@@ -1,4 +1,4 @@
-from typing import NamedTuple, Optional, Union
+from typing import NamedTuple, Optional
 
 import numpy as np
 from numpy import ndarray

--- a/skfem/element/discrete_field.py
+++ b/skfem/element/discrete_field.py
@@ -1,4 +1,4 @@
-from typing import NamedTuple, Optional
+from typing import NamedTuple, Optional, Union
 
 import numpy as np
 from numpy import ndarray
@@ -7,7 +7,7 @@ from numpy import ndarray
 class DiscreteField(NamedTuple):
     """A function defined at the global quadrature points."""
 
-    value: ndarray
+    value: ndarray = np.array([0])  # zero field
     grad: Optional[ndarray] = None
     div: Optional[ndarray] = None
     curl: Optional[ndarray] = None
@@ -67,6 +67,11 @@ class DiscreteField(NamedTuple):
         """Split all components based on their first dimension."""
         return [DiscreteField(*[f[i] for f in self if f is not None])
                 for i in range(self.value.shape[0])]
+
+    def is_zero(self):
+        if self.value.shape == (1,):
+            return True
+        return False
 
     def zeros_like(self) -> 'DiscreteField':
         """Return zero :class:`~skfem.element.DiscreteField` with same size."""

--- a/skfem/element/element.py
+++ b/skfem/element/element.py
@@ -99,23 +99,26 @@ class Element:
 
     def condensed(self):
 
-        eo = Element()
-        eo.nodal_dofs = self.nodal_dofs
-        eo.facet_dofs = self.facet_dofs
-        eo.edge_dofs = self.edge_dofs
+        from types import MethodType
+        from copy import deepcopy
+
+        eo = deepcopy(self)
         eo.interior_dofs = 0
-        eo.refdom = self.refdom
-        eo.maxdeg = self.maxdeg
 
-        eo.gbasis = self.gbasis
+        if hasattr(eo, 'elems'):
+            for i in range(len(eo.elems)):
+                eo.elems[i].interior_dofs = 0
 
-        ei = Element()
+        ei = deepcopy(self)
         ei.nodal_dofs = 0
         ei.facet_dofs = 0
         ei.edge_dofs = 0
-        ei.interior_dofs = self.interior_dofs
-        ei.refdom = self.refdom
-        ei.maxdeg = self.maxdeg
+
+        if hasattr(ei, 'elems'):
+            for i in range(len(ei.elems)):
+                ei.elems[i].nodal_dofs = 0
+                ei.elems[i].facet_dofs = 0
+                ei.elems[i].edge_dofs = 0
 
         def gbasis(obj,
                    mapping,
@@ -127,9 +130,7 @@ class Element:
                                i + self._bfun_counts()[:3].sum(),
                                tind)
 
-        import types
-
-        ei.gbasis = types.MethodType(gbasis, ei)
+        ei.gbasis = MethodType(gbasis, ei)
 
         return eo, ei
 

--- a/skfem/element/element.py
+++ b/skfem/element/element.py
@@ -1,4 +1,6 @@
 from typing import Optional, List, Type, Tuple
+from types import MethodType
+from copy import deepcopy
 
 import numpy as np
 from numpy import ndarray
@@ -99,9 +101,6 @@ class Element:
 
     def condensed(self):
         """Return two elements: one for interior and one for other DOFs."""
-
-        from types import MethodType
-        from copy import deepcopy
 
         eo = deepcopy(self)
         eo.interior_dofs = 0

--- a/skfem/element/element.py
+++ b/skfem/element/element.py
@@ -98,6 +98,7 @@ class Element:
         raise ValueError("Index larger than the number of basis functions.")
 
     def condensed(self):
+        """Return two elements: one for interior and one for other DOFs."""
 
         from types import MethodType
         from copy import deepcopy
@@ -132,8 +133,7 @@ class Element:
 
         ei.gbasis = MethodType(gbasis, ei)
 
-        return eo, ei
-
+        return ei, eo
 
     def _bfun_counts(self) -> ndarray:
         """Count number of nodal/edge/facet/interior basis functions."""

--- a/skfem/element/element.py
+++ b/skfem/element/element.py
@@ -97,6 +97,43 @@ class Element:
     def _index_error(cls):
         raise ValueError("Index larger than the number of basis functions.")
 
+    def condensed(self):
+
+        eo = Element()
+        eo.nodal_dofs = self.nodal_dofs
+        eo.facet_dofs = self.facet_dofs
+        eo.edge_dofs = self.edge_dofs
+        eo.interior_dofs = 0
+        eo.refdom = self.refdom
+        eo.maxdeg = self.maxdeg
+
+        eo.gbasis = self.gbasis
+
+        ei = Element()
+        ei.nodal_dofs = 0
+        ei.facet_dofs = 0
+        ei.edge_dofs = 0
+        ei.interior_dofs = self.interior_dofs
+        ei.refdom = self.refdom
+        ei.maxdeg = self.maxdeg
+
+        def gbasis(obj,
+                   mapping,
+                   X: ndarray,
+                   i: int,
+                   tind: Optional[ndarray] = None):
+            return self.gbasis(mapping,
+                               X,
+                               i + self._bfun_counts()[:3].sum(),
+                               tind)
+
+        import types
+
+        ei.gbasis = types.MethodType(gbasis, ei)
+
+        return eo, ei
+
+
     def _bfun_counts(self) -> ndarray:
         """Count number of nodal/edge/facet/interior basis functions."""
         return np.array([self.nodal_dofs * self.refdom.nnodes,

--- a/skfem/element/element_composite.py
+++ b/skfem/element/element_composite.py
@@ -100,8 +100,5 @@ class ElementComposite(Element):
             if n == k:
                 output.append(e.gbasis(mapping, X, ind, tind)[0])
             else:
-                # TODO change to something like
-                # output.append(0)
-                # requires changes at least in AbstractBasis
-                output.append(e.gbasis(mapping, X, 0, tind)[0].zeros_like())
+                output.append(DiscreteField())
         return tuple(output)

--- a/skfem/element/element_composite.py
+++ b/skfem/element/element_composite.py
@@ -100,5 +100,8 @@ class ElementComposite(Element):
             if n == k:
                 output.append(e.gbasis(mapping, X, ind, tind)[0])
             else:
+                # TODO change to something like
+                # output.append(0)
+                # requires changes at least in AbstractBasis
                 output.append(e.gbasis(mapping, X, 0, tind)[0].zeros_like())
         return tuple(output)

--- a/skfem/helpers.py
+++ b/skfem/helpers.py
@@ -11,10 +11,23 @@ IntOrField = Union[int, DiscreteField]
 IntFieldOrArray = Union[int, DiscreteField, ndarray]
 
 
-def unpack(w: FormExtraParams, k: int, *args):
+def jump(w: FormExtraParams, *args):
+    if not hasattr(w, 'idx'):
+        raise NotImplementedError("jump() can be used only if the form is "
+                                  "assembled through asm().")
     out = []
     for i, arg in enumerate(args):
-        out.append(tuple(arg if w.idx[i] == j else 0 for j in range(k)))
+        out.append((-1.) ** w.idx[i] * arg)
+    return out[0] if len(out) == 1 else tuple(out)
+
+
+def unpack(w: FormExtraParams, *args):
+    if not hasattr(w, 'idx'):
+        raise NotImplementedError("split() can be used only if the form is "
+                                  "assembled through asm().")
+    out = []
+    for i, arg in enumerate(args):
+        out.append(tuple(arg if w.idx[i] == j else 0 for j in range(w.maxidx)))
     return tuple(out)
 
 

--- a/skfem/helpers.py
+++ b/skfem/helpers.py
@@ -142,7 +142,7 @@ def eye(w, n):
 
 def identity(w, N=None):
     """Create identity matrix."""
-    if isinstance(w, IntOrField):
+    if isinstance(w, DiscreteField):
         proto = w.value
     elif isinstance(w, ndarray):
         proto = w

--- a/skfem/helpers.py
+++ b/skfem/helpers.py
@@ -23,7 +23,7 @@ def jump(w: FormExtraParams, *args):
 
 def unpack(w: FormExtraParams, *args):
     if not hasattr(w, 'idx'):
-        raise NotImplementedError("split() can be used only if the form is "
+        raise NotImplementedError("unpack() can be used only if the form is "
                                   "assembled through asm().")
     out = []
     for i, arg in enumerate(args):

--- a/skfem/helpers.py
+++ b/skfem/helpers.py
@@ -20,19 +20,6 @@ def jump(w: FormExtraParams, *args):
     return out[0] if len(out) == 1 else tuple(out)
 
 
-def unpack(w: FormExtraParams, *args):
-    if not hasattr(w, 'idx'):
-        raise NotImplementedError("unpack() can be used only if the form is "
-                                  "assembled through asm().")
-    out = []
-    for i, arg in enumerate(args):
-        out.append(tuple(arg
-                         if w.idx[i] == j
-                         else DiscreteField()
-                         for j in range(w.maxidx)))
-    return tuple(out)
-
-
 def grad(u: DiscreteField):
     """Gradient."""
     if u.is_zero():

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -150,6 +150,8 @@ class TestComposite(TestCase):
         for k in range(6):
             for i in [0, 1]:
                 # accessing i'th component looks slightly different
+                if ec.gbasis(mapping, X, k)[i].is_zero():
+                    continue
                 assert_array_equal(
                     ev.gbasis(mapping, X, k)[0].value[i],
                     ec.gbasis(mapping, X, k)[i].value


### PR DESCRIPTION
Update on the changes:

- Added `skfem.helpers.jump`.
- `asm()` now accepts and uses the keyword argument `asm(..., to=list)` which, instead of summing the resulting `COOData` objects, will apply the function given via `to` to the resulting `map` object. E.g., `asm(..., to=list)` will return a list of `COOData` objects, each representing different blocks.
- Now empty `DiscreteField()` will represent a "zero field" which is taken into account in most of `skfem.helpers` and allows for optimizing vectorial forms: no need to calculate multiplications with huge dense arrays filled with zeros.
- `ElementComposite` will now pass `DiscreteField()` to the unused component instead of huge zero arrays. [This is the scariest part, after changes no tests are broken but I think it may in some untested edge cases break code that worked in the previous versions.]
- The support for zero `DiscreteField()` was added to `AbstractBasis.interpolate`.
- `COOData.tolocal()` and `COOData.fromlocal()` for getting a 3-tensor of local stiffness matrices and transforming that back to `COOData` internal format for creating, e.g., CSR matrices. This is for manipulating and possibly inverting local stiffness matrices using `np.linalg.inv`.
- `Element.condensed` will return a pair of new `Element` objects: one with all the interior DOFs and one with all the remaining DOFs.

All of this was done to support for static condensation of interior DOFs. Here is an example how to condense the bubble DOFs for MINI element in Stokes problem:
```python
import numpy as np
from skfem import *


m = MeshTri().refined(4)
el = ElementVector(ElementTriMini()) * ElementTriP1()
elems = el.condensed()
bases = [Basis(m, e) for e in elems]


@BilinearForm
def stokes(u, p, v, q, w):
    from skfem.helpers import ddot, grad, div
    return ddot(grad(u), grad(v)) - div(u) * q - div(v) * p - 1e-2 * p * q


K = asm(stokes, bases, bases, to=list)

# static condensation
A = K[3].tocsr()
B = K[2].tocsr()
invC = K[0].inverse().tocsr()
S = A - B.T @ invC @ B


D = bases[1].get_dofs()
Dup = bases[1].get_dofs(lambda x: np.isclose(x[1], 1))
x = np.zeros(S.shape[0])
x[Dup.all('u^1^1')] = 1
x = solve(*condense(S, x=x, D=D.all(['u^1^1', 'u^2^1'])))

(u, ub), (p, pb) = bases[1].split(x)

from skfem.visuals.matplotlib import plot, show
plot(pb, p)
show()
```
The syntax is not yet too cool but now it's technically possible.