### PR TITLE
use predefined values (also used later to compute exact solution)

### DIFF
--- a/docs/examples/ex17.py
+++ b/docs/examples/ex17.py
@@ -57,7 +57,7 @@ basis0 = basis.with_element(ElementQuad0())
 
 conductivity = basis0.zeros()
 for s in mesh.subdomains:
-    conductivity[basis0.get_dofs(elements=s)] = thermal_conductivity(s)
+    conductivity[basis0.get_dofs(elements=s)] = thermal_conductivity[s]
 
 L = asm(conduction, basis, conductivity=basis0.interpolate(conductivity))
 

--- a/docs/examples/ex17.py
+++ b/docs/examples/ex17.py
@@ -56,8 +56,8 @@ basis = Basis(mesh, element)
 basis0 = basis.with_element(ElementQuad0())
 
 conductivity = basis0.zeros()
-conductivity[basis0.get_dofs(elements='core')] = 101.
-conductivity[basis0.get_dofs(elements='annulus')] = 11.
+for s in mesh.subdomains:
+    conductivity[basis0.get_dofs(elements=s)] = thermal_conductivity(s)
 
 L = asm(conduction, basis, conductivity=basis0.interpolate(conductivity))
 


### PR DESCRIPTION
The recent improvement to ex17, defining thermal conductivity by subdomain and therefore by element, is good, but should not repeat the hard-coded values.