### PR TITLE
Make meshio optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,9 +163,9 @@ The minimal dependencies for installing `scikit-fem` are
 many
 [examples](https://scikit-fem.readthedocs.io/en/latest/listofexamples.html) use
 [matplotlib](https://matplotlib.org/) for visualization and
-[meshio](https://github.com/nschloe/meshio) for loading external formats.  Some
-examples demonstrate the use of other external packages; see `requirements.txt`
-for a list of test dependencies.
+[meshio](https://github.com/nschloe/meshio) for loading/saving different mesh
+file formats.  Some examples demonstrate the use of other external packages;
+see `requirements.txt` for a list of test dependencies.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -27,8 +27,12 @@ Features:
 
 The most recent release can be installed simply by
 ```
-pip install scikit-fem
+pip install scikit-fem[all]
 ```
+Specifying `[all]` includes `meshio` for loading
+and saving to external formats,
+and `matplotlib` for visualization.
+The minimal dependencies are `numpy` and `scipy`.
 You can also try the library in browser through [Google Colab](https://colab.research.google.com/github/kinnala/scikit-fem-notebooks/blob/master/ex1.ipynb).
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -159,12 +159,13 @@ python -c "import pkg_resources; print(pkg_resources.get_distribution('scikit-fe
 ## Dependencies
 
 The minimal dependencies for installing `scikit-fem` are
-[numpy](https://numpy.org/), [scipy](https://www.scipy.org/) and
-[meshio](https://github.com/nschloe/meshio).  In addition, many
+[numpy](https://numpy.org/) and [scipy](https://www.scipy.org/).  In addition,
+many
 [examples](https://scikit-fem.readthedocs.io/en/latest/listofexamples.html) use
-[matplotlib](https://matplotlib.org/) for visualization.  Some examples
-demonstrate the use of other external packages; see `requirements.txt` for a
-list of test dependencies.
+[matplotlib](https://matplotlib.org/) for visualization and
+[meshio](https://github.com/nschloe/meshio) for loading external formats.  Some
+examples demonstrate the use of other external packages; see `requirements.txt`
+for a list of test dependencies.
 
 ## Testing
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,11 +28,13 @@ packages = find:
 install_requires =
     numpy
     scipy
-    meshio>=4.0.4
 python_requires = >=3.7
 setup_requires =
     setuptools>=42
     wheel
+
+[options.extras_require]
+all = meshio>=4.0.4; matplotlib
 
 [options.packages.find]
 exclude =


### PR DESCRIPTION
Many use cases work without `meshio` so I thought about making it optional and suggesting in readme to install via `pip install scikit-fem[all]` to get also `meshio` and `matplotlib`. What do you think @gdmcbain? The minimal installation could be useful, e.g., in some libraries using `scikit-fem` as a dependency. I'm not including `vedo` in `[all]` because it pulls quite many dependencies and I've noticed the installation to be a bit unpredictable in different environments, e.g., in JupyterHub/Google Colab.