### PR TITLE
Implement AbstractBasis.project & improvements to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The most recent release can be installed simply by
 pip install scikit-fem[all]
 ```
 Specifying `[all]` includes `meshio` for mesh input/output,
-and `matplotlib` for simple visualization.
+and `matplotlib` for simple visualizations.
 The minimal dependencies are `numpy` and `scipy`.
 You can also try the library in browser through [Google Colab](https://colab.research.google.com/github/kinnala/scikit-fem-notebooks/blob/master/ex1.ipynb).
 

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@
 </p>
 
 
-`scikit-fem` is a lightweight Python 3.7+ library for performing [finite element
-assembly](https://en.wikipedia.org/wiki/Finite_element_method). Its main purpose
-is the transformation of bilinear forms into sparse matrices and linear forms
-into vectors.
+`scikit-fem` is a lightweight pure Python 3.7+ library for performing [finite
+element assembly](https://en.wikipedia.org/wiki/Finite_element_method). Its
+main purpose is the transformation of bilinear forms into sparse matrices and
+linear forms into vectors.
 
 Features:
 - minimal dependencies, no compiled code
@@ -29,8 +29,8 @@ The most recent release can be installed simply by
 ```
 pip install scikit-fem[all]
 ```
-Specifying `[all]` includes `meshio` for mesh input/output,
-and `matplotlib` for simple visualizations.
+Remove `[all]` to not install the optional dependencies `meshio` for mesh
+input/output, and `matplotlib` for creating simple visualizations.
 The minimal dependencies are `numpy` and `scipy`.
 You can also try the library in browser through [Google Colab](https://colab.research.google.com/github/kinnala/scikit-fem-notebooks/blob/master/ex1.ipynb).
 

--- a/README.md
+++ b/README.md
@@ -348,6 +348,8 @@ with respect to documented and/or tested features.
 - Removed: `skfem.models.helpers`; available as `skfem.helpers`
 - Removed: `DiscreteField.{f,df,ddf,hod}`; available as `DiscreteField.{value,grad,hess,grad3,...}`
 - Removed: Python 3.6 support
+- Removed: `skfem.utils.L2_projection`
+- Removed: `skfem.utils.derivative`
 - Changed: `Mesh.refined` no more attempts to fix the indexing of `Mesh.boundaries` after refine
 - Changed: `skfem.utils.solve` now uses `scipy.sparse.eigs` instead of `scipy.sparse.eigsh` by default;
   the old behavior can be retained by explicitly passing `solver=solver_scipy_eigs_sym()`

--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ with respect to documented and/or tested features.
 
 - Added: `ElementTriCCR` and `ElementTetCCR`, conforming Crouzeix-Raviart finite elements
 - Fixed: `Mesh.mirrored` returned a wrong mesh when a point other than the origin was used
-- Fixed: `MeshLine` constructor accepted only NumPy arrays and not plain Python lists
+- Fixed: `MeshLine` constructor accepted only numpy arrays and not plain Python lists
 - Fixed: `Mesh.element_finder` (and `CellBasis.probes`, `CellBasis.interpolator`) was not working properly for a small number of elements (<5) or a large number of input points (>1000)
 - Fixed: `MeshTet` and `MeshTri.element_finder` are now more robust against degenerate elements
 - Fixed: `Mesh.element_finder` (and `CellBasis.probes`, `CellBasis.interpolator`) raises exception if the query point is outside of the domain

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -108,7 +108,7 @@ allows experimenting:
    array([[2., 2., 2.],
           [1., 1., 1.]])
 
-Notice how ``dot(grad(u), grad(v))`` is a NumPy array with the shape `number of
+Notice how ``dot(grad(u), grad(v))`` is a numpy array with the shape `number of
 elements` x `number of quadrature points per element`.  The return value should
 always have such shape no matter which mesh or element type is used.
 
@@ -124,7 +124,7 @@ readable.  An alternative way to write the above form is
 
 .. note::
 
-    In fact, ``u`` and ``v`` are simply named tuples of NumPy arrays with the
+    In fact, ``u`` and ``v`` are simply named tuples of numpy arrays with the
     values of the function at ``u[0]`` or ``u.value`` and the values of the
     gradient at ``u[1]`` or ``u.grad`` (and some additional magic such as
     implementing ``__array__`` and ``__mul__`` so that expressions such as
@@ -190,6 +190,12 @@ cube mesh:
      Number of DOFs: 27
      Size: 296352 B
 
+.. plot::
+
+   from skfem import *
+   from skfem.visuals.matplotlib import *
+   draw(MeshHex())
+
 The DOFs corresponding to the nodes (or vertices) of the mesh are
 
 .. doctest::
@@ -201,6 +207,16 @@ This means that the first (zeroth) entry in the DOF array corresponds to the
 first node/vertex in the finite element mesh (see ``m.p`` for a list of
 nodes/vertices).
 
+.. plot::
+
+   from skfem import *
+   from skfem.visuals.matplotlib import *
+   m = MeshHex()
+   basis = Basis(m, ElementHex2())
+   ax = draw(m)
+   for dof in basis.nodal_dofs.flatten():
+       ax.text(*basis.doflocs[:, dof], str(dof))
+
 Similarly, the DOFs corresponding to the edges (``m.edges`` for a list of
 edges) and the facets (``m.facets`` for a list of facets) of the mesh are
 
@@ -210,6 +226,26 @@ edges) and the facets (``m.facets`` for a list of facets) of the mesh are
    array([[ 8,  9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]])
    >>> basis.facet_dofs
    array([[20, 21, 22, 23, 24, 25]])
+
+.. plot::
+
+   from skfem import *
+   from skfem.visuals.matplotlib import *
+   m = MeshHex()
+   basis = Basis(m, ElementHex2())
+   ax = draw(m)
+   for dof in basis.edge_dofs.flatten():
+       ax.text(*basis.doflocs[:, dof], str(dof))
+
+.. plot::
+
+   from skfem import *
+   from skfem.visuals.matplotlib import *
+   m = MeshHex()
+   basis = Basis(m, ElementHex2())
+   ax = draw(m)
+   for dof in basis.facet_dofs.flatten():
+       ax.text(*basis.doflocs[:, dof], str(dof))
 
 All DOFs in ``nodal_dofs``, ``edge_dofs`` and ``facet_dofs``
 are shared between neighbouring elements to preserve continuity.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -130,9 +130,58 @@ Module: skfem.element
 =====================
 
 .. automodule:: skfem.element
-   :members:
    :show-inheritance:
-   :exclude-members: DiscreteField, ElementVectorH1
+
+.. autosummary::
+
+    skfem.element.ElementH1
+    skfem.element.ElementVector
+    skfem.element.ElementHdiv
+    skfem.element.ElementHcurl
+    skfem.element.ElementGlobal
+    skfem.element.ElementDG
+    skfem.element.ElementComposite
+    skfem.element.ElementTriP1
+    skfem.element.ElementTriP2
+    skfem.element.ElementTriP3
+    skfem.element.ElementTriP4
+    skfem.element.ElementTriP0
+    skfem.element.ElementTriCR
+    skfem.element.ElementTriCCR
+    skfem.element.ElementTriRT0
+    skfem.element.ElementTriMorley
+    skfem.element.ElementTri15ParamPlate
+    skfem.element.ElementTriArgyris
+    skfem.element.ElementTriMini
+    skfem.element.ElementTriHermite
+    skfem.element.ElementTriSkeletonP0
+    skfem.element.ElementTriSkeletonP1
+    skfem.element.ElementTriBDM1
+    skfem.element.ElementQuad0
+    skfem.element.ElementQuad1
+    skfem.element.ElementQuad2
+    skfem.element.ElementQuadS2
+    skfem.element.ElementQuadP
+    skfem.element.ElementQuadBFS
+    skfem.element.ElementTetP0
+    skfem.element.ElementTetP1
+    skfem.element.ElementTetP2
+    skfem.element.ElementTetRT0
+    skfem.element.ElementTetN0
+    skfem.element.ElementTetMini
+    skfem.element.ElementTetCR
+    skfem.element.ElementTetCCR
+    skfem.element.ElementHex0
+    skfem.element.ElementHex1
+    skfem.element.ElementHex2
+    skfem.element.ElementHexS2
+    skfem.element.ElementLineP0
+    skfem.element.ElementLineP1
+    skfem.element.ElementLineP2
+    skfem.element.ElementLinePp
+    skfem.element.ElementLineHermite
+    skfem.element.ElementLineMini
+   
 
 .. note::
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -87,7 +87,7 @@ Class: CellBasis
 .. autoclass:: skfem.assembly.Basis
 
 .. autoclass:: skfem.assembly.CellBasis
-   :members: __init__, interpolate
+   :members: __init__, interpolate, project
 
 
 Class: BoundaryFacetBasis
@@ -134,6 +134,17 @@ Module: skfem.element
    :show-inheritance:
    :exclude-members: DiscreteField, ElementVectorH1
 
+.. note::
+
+   The element global basis is calculated at quadrature points and stored inside
+   :class:`~skfem.element.DiscreteField` objects.
+   The different element types precalculate different fields of
+   :class:`~skfem.element.DiscreteField`.  E.g., for :math:`H(div)`
+   finite elements it is natural to precalculate ``DiscreteField.div``.
+   The high order derivatives are created only when using subclasses of
+   :class:`~skfem.element.ElementGlobal`.
+                 
+
 .. autoclass:: skfem.element.DiscreteField
 
 Module: skfem.utils
@@ -154,11 +165,6 @@ Function: enforce
 
 .. autofunction:: skfem.utils.enforce
 
-Function: projection
---------------------
-
-.. autofunction:: skfem.utils.projection
-
 Module: skfem.helpers
 =====================
 
@@ -174,8 +180,24 @@ Module: skfem.helpers
 
 .. autofunction:: skfem.helpers.dd
 
+.. autofunction:: skfem.helpers.ddd
+
+.. autofunction:: skfem.helpers.dddd
+
 .. autofunction:: skfem.helpers.sym_grad
 
 .. autofunction:: skfem.helpers.dot
 
 .. autofunction:: skfem.helpers.ddot
+
+.. autofunction:: skfem.helpers.dddot
+
+.. autofunction:: skfem.helpers.mul
+
+.. autofunction:: skfem.helpers.trace
+
+.. autofunction:: skfem.helpers.transpose
+
+.. autofunction:: skfem.helpers.prod
+
+.. autofunction:: skfem.helpers.inv

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,6 +45,7 @@ extensions = [
     'sphinx.ext.napoleon',
     'sphinx.ext.autosummary',
     'sphinx.ext.doctest',
+    'matplotlib.sphinxext.plot_directive',
 ]
 
 autosummary_generate = True
@@ -81,7 +82,7 @@ pygments_style = 'sphinx'
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'sphinx_rtd_theme'
+html_theme = 'alabaster'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/docs/examples/ex03.py
+++ b/docs/examples/ex03.py
@@ -45,12 +45,7 @@ y = x[:, 4]
 sgb = gb.with_element(ElementVector(e))
 C = linear_stress(lam, mu)
 yi = gb.interpolate(y)
-
-@LinearForm
-def proj(v, _):
-    return ddot(C(sym_grad(yi)), v)
-
-sigma = projection(proj, sgb, gb)
+sigma = sgb.project(C(sym_grad(yi)))
 
 if __name__ == "__main__":
     from skfem.visuals.matplotlib import plot, draw, show

--- a/docs/examples/ex14.py
+++ b/docs/examples/ex14.py
@@ -38,12 +38,8 @@ def dirichlet(x):
     return ((x[0] + 1.j * x[1]) ** 2).real
 
 
-boundary_basis = FacetBasis(m, e)
-boundary_dofs = basis.get_dofs()
-
-u = basis.zeros()
-u[boundary_dofs] = projection(dirichlet, boundary_basis, I=boundary_dofs)
-u = solve(*condense(A, x=u, D=boundary_dofs))
+u = basis.project(dirichlet)
+u = solve(*condense(A, x=u, D=basis.get_dofs()))
 
 
 if __name__ == "__main__":

--- a/docs/examples/ex27.py
+++ b/docs/examples/ex27.py
@@ -130,10 +130,10 @@ class BackwardFacingStep:
 
     def make_vector(self):
         """prepopulate solution vector with Dirichlet conditions"""
-        uvp = np.zeros(self.basis['u'].N + self.basis['p'].N)
-        I = self.inlet_dofs()
-        uvp[I] = projection(self.parabolic, self.basis['inlet'], I=I)
-        return uvp
+        return np.hstack((
+            self.basis['inlet'].project(self.parabolic),
+            self.basis['p'].zeros()
+        ))
 
     def split(self, solution: np.ndarray) -> Tuple[np.ndarray,
                                                    np.ndarray]:

--- a/docs/examples/ex33.py
+++ b/docs/examples/ex33.py
@@ -59,4 +59,4 @@ if __name__ == '__main__':
     from sys import argv
     name = splitext(argv[0])[0]
 
-    m.save('{}_solution.vtk'.format(name), {'field': y[y_basis.nodal_dofs].T})
+    m.save('{}_solution.vtk'.format(name), {'field': y[ybasis.nodal_dofs].T})

--- a/docs/examples/ex33.py
+++ b/docs/examples/ex33.py
@@ -50,8 +50,8 @@ D = basis.get_dofs()
 
 x = solve(*condense(A, f, D=D))
 
-y_basis = basis.with_element(ElementVector(ElementTetP1()))
-y = projection(x, y_basis, basis)
+ybasis = basis.with_element(ElementVector(ElementTetP1()))
+y = ybasis.project(basis.interpolate(x))
 
 if __name__ == '__main__':
 

--- a/docs/examples/ex35.py
+++ b/docs/examples/ex35.py
@@ -349,11 +349,13 @@ if __name__ == '__main__':
     from skfem.visuals.matplotlib import plot, savefig
     import matplotlib.pyplot as plt
 
-    B_x = global_basis.project(lambda w: w['A'].grad[1], A=A)
-    B_y = -global_basis.project(lambda w: w['A'].grad[0], A=A)
+    Ai = global_basis.interpolate(A)
+    B_x = global_basis.project(Ai.grad[1])
+    B_y = -global_basis.project(Ai.grad[0])
 
-    E_x = -global_basis.project(lambda w: w['U'].grad[0], U=U)
-    E_y = -global_basis.project(lambda w: w['U'].grad[1], U=U)
+    Ui = global_basis.interpolate(U)
+    E_x = -global_basis.project(Ui.grad[0])
+    E_y = -global_basis.project(Ui.grad[1])
 
     fig = plt.figure(figsize=(11.52, 5.12))
 

--- a/docs/examples/ex35.py
+++ b/docs/examples/ex35.py
@@ -317,18 +317,14 @@ K_elec = (
 voltage = 1
 
 # initialize the non-homogeneous Dirichlet conditions on the conductor surfaces
-U = np.zeros(K_elec.shape[0])
-U[dofs['inner_conductor_outer_surface']] = projection(
-    lambda x: voltage/2, inner_conductor_outer_surface_basis,
-    I=dofs['inner_conductor_outer_surface'])
-U[dofs['outer_conductor_inner_surface']] = projection(
-    lambda x: -voltage/2, outer_conductor_inner_surface_basis,
-    I=dofs['outer_conductor_inner_surface'])
+U = inner_conductor_outer_surface_basis.project(voltage / 2.)
+U += outer_conductor_inner_surface_basis.project(-voltage / 2.)
+D = np.hstack((
+    dofs['inner_conductor_outer_surface'],
+    dofs['outer_conductor_inner_surface'],
+))
 
-U = solve(*condense(
-    K_elec, x=U,
-    D=dofs['inner_conductor_outer_surface'] |
-    dofs['outer_conductor_inner_surface']))
+U = solve(*condense(K_elec, x=U, D=D))
 
 # electric field energy
 E_elec = 0.5*np.dot(U, K_elec*U)
@@ -353,11 +349,11 @@ if __name__ == '__main__':
     from skfem.visuals.matplotlib import plot, savefig
     import matplotlib.pyplot as plt
 
-    B_x = projection(A, global_basis, global_basis, 1)
-    B_y = -projection(A, global_basis, global_basis, 0)
+    B_x = global_basis.project(lambda w: w['A'].grad[1], A=A)
+    B_y = -global_basis.project(lambda w: w['A'].grad[0], A=A)
 
-    E_x = -projection(U, global_basis, global_basis, 0)
-    E_y = -projection(U, global_basis, global_basis, 1)
+    E_x = -global_basis.project(lambda w: w['U'].grad[0], U=U)
+    E_y = -global_basis.project(lambda w: w['U'].grad[1], U=U)
 
     fig = plt.figure(figsize=(11.52, 5.12))
 

--- a/docs/examples/ex38.py
+++ b/docs/examples/ex38.py
@@ -47,9 +47,8 @@ b = basis.point_source(source)
 
 x = solve(*condense(A, b, D=basis.get_dofs()))
 
-exact = projection(
-    partial(greens, np.linalg.norm(basis.mesh.p, axis=0).max(), source), basis
-)
+a = np.linalg.norm(basis.mesh.p, axis=0).max()
+exact = basis.project(lambda x: greens(a, source, x))
 error = x - exact
 l2error = np.sqrt(error @ mass.assemble(basis) @ error)
 

--- a/docs/gettingstarted.rst
+++ b/docs/gettingstarted.rst
@@ -12,7 +12,7 @@ install the package via
    pip install scikit-fem[all]
 
 Specifying ``[all]`` includes ``meshio`` for mesh input/output, and
-``matplotlib`` for simple visualization.  The minimal dependencies are
+``matplotlib`` for simple visualizations.  The minimal dependencies are
 ``numpy`` and ``scipy``.  You can also install scikit-fem in `Google Colab
 <https://colab.research.google.com/>`_ by executing
 

--- a/docs/gettingstarted.rst
+++ b/docs/gettingstarted.rst
@@ -171,7 +171,8 @@ which is a simple wrapper to ``scipy`` sparse solver:
    a = BilinearForm(lambda u, v, _: dot(grad(u), grad(v)))
    L = LinearForm(lambda v, w: np.sin(np.pi * w.x[0]) * np.sin(np.pi * w.x[1]) * v)
    y = solve(*condense(a.assemble(basis), L.assemble(basis), D=basis.get_dofs()))
-   plot(basis, y, nrefs=3, colorbar=True)
+   ax = draw(basis)
+   plot(basis, y, ax=ax, nrefs=3, colorbar=True)
 
 
 Step 8: Calculate error

--- a/docs/gettingstarted.rst
+++ b/docs/gettingstarted.rst
@@ -11,12 +11,14 @@ install the package via
 
    pip install scikit-fem[all]
 
-You can also try `Google Colab <https://colab.research.google.com/>`_ in your
-web browser and install scikit-fem by executing
+Specifying ``[all]`` includes ``meshio`` for mesh input/output, and
+``matplotlib`` for simple visualization.  The minimal dependencies are
+``numpy`` and ``scipy``.  You can also install scikit-fem in `Google Colab
+<https://colab.research.google.com/>`_ by executing
 
 .. code-block:: bash
 
-   !pip install scikit-fem[all]
+   !pip install scikit-fem
 
 Step 1: Clarify the problem
 ===========================
@@ -39,11 +41,9 @@ find :math:`u \in H^1_0(\Omega)` satisfying
 
 .. note::
 
-   Above :math:`H^1_0(\Omega)` is the space of functions that are zero
-   on the boundary :math:`\partial \Omega` and the square integral of the
-   first derivative is finite.  This is a common function space
-   to use for second-order boundary value problems because 
-   it often corresponds to the space of functions with finite energy.
+   :math:`H^1_0(\Omega)` is the space of functions that are zero on the
+   boundary :math:`\partial \Omega` and have finite energy: the square integral
+   of the first derivative is finite.
 
 Step 2: Express the forms as code
 =================================

--- a/docs/gettingstarted.rst
+++ b/docs/gettingstarted.rst
@@ -93,6 +93,13 @@ unit square:
      Named boundaries [# facets]: left [8], bottom [8], right [8], top [8]
 
 
+.. plot::
+
+   from skfem import *
+   from skfem.visuals.matplotlib import *
+   draw(MeshTri().refined(3))
+
+
 Step 4: Define a basis
 ======================
 
@@ -153,6 +160,19 @@ which is a simple wrapper to ``scipy`` sparse solver:
    >>> x = fem.solve(*fem.condense(A, l, D=D))
    >>> x.shape
    (81,)
+
+.. plot::
+
+   from skfem import *
+   from skfem.visuals.matplotlib import *
+   from skfem.helpers import dot, grad
+   import numpy as np
+   basis = Basis(MeshTri().refined(3), ElementTriP1())
+   a = BilinearForm(lambda u, v, _: dot(grad(u), grad(v)))
+   L = LinearForm(lambda v, w: np.sin(np.pi * w.x[0]) * np.sin(np.pi * w.x[1]) * v)
+   y = solve(*condense(a.assemble(basis), L.assemble(basis), D=basis.get_dofs()))
+   plot(basis, y, nrefs=3, colorbar=True)
+
 
 Step 8: Calculate error
 =======================

--- a/docs/howto.rst
+++ b/docs/howto.rst
@@ -117,12 +117,12 @@ Below we solve explicitly the above variational problem:
           0.     , 0.61237, 0.15811, 0.61237, 0.15811, 0.     , 0.     ,
           0.     , 0.     ])
 
-Alternatively, you can use :func:`skfem.utils.projection` which does exactly
-the same thing:
+Alternatively, you can use :meth:`~skfem.assembly.AbstractBasis.project` which
+does exactly the same thing:
 
 .. doctest::
 
-   >>> y = fem.projection(u_0, basis, I=basis.get_dofs(), expand=True)
+   >>> y = basis.project(u_0)
    >>> np.abs(np.round(y, 5))
    array([0.     , 0.     , 1.     , 0.     , 0.     , 0.     , 0.     ,
           0.     , 0.61237, 0.15811, 0.61237, 0.15811, 0.     , 0.     ,

--- a/docs/howto.rst
+++ b/docs/howto.rst
@@ -128,6 +128,8 @@ as follows:
 
 See :ref:`dofindexing` for more details.
 
+.. _l2proj:
+
 Performing :math:`L^2` projections
 ==================================
 

--- a/docs/howto.rst
+++ b/docs/howto.rst
@@ -130,8 +130,8 @@ See :ref:`dofindexing` for more details.
 
 .. _l2proj:
 
-Performing :math:`L^2` projections
-==================================
+Performing projections
+======================
 
 We can use :math:`L^2` projection to find discrete counterparts of functions or
 transform from one finite element basis to another.  Suppose we have

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,7 +17,7 @@ hexahedral meshes as well as one-dimensional problems.
 
         pip install scikit-fem[all]
 
-    Examples can be found in the `gallery <listofexamples.html>`_.
+    Remove ``[all]`` to not install ``meshio`` and ``matplotlib``.
 
 Table of contents
 =================

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,8 +2,8 @@
  Documentation of scikit-fem
 =============================
 
-`scikit-fem <https://github.com/kinnala/scikit-fem>`_ is a lightweight Python 3.7+
-library for performing `finite element assembly
+`scikit-fem <https://github.com/kinnala/scikit-fem>`_ is a lightweight pure
+Python 3.7+ library for performing `finite element assembly
 <https://en.wikipedia.org/wiki/Finite_element_method>`_. Its main purpose is
 the transformation of bilinear forms into sparse matrices and linear forms into
 vectors.  The library supports triangular, quadrilateral, tetrahedral and
@@ -17,7 +17,8 @@ hexahedral meshes as well as one-dimensional problems.
 
         pip install scikit-fem[all]
 
-    Remove ``[all]`` to not install ``meshio`` and ``matplotlib``.
+    Remove ``[all]`` to not install the optional dependencies ``meshio`` and
+    ``matplotlib``.
 
 Table of contents
 =================

--- a/docs/listofexamples.rst
+++ b/docs/listofexamples.rst
@@ -21,6 +21,7 @@ triangular elements.
 
 See the `source code of Example 1 <https://github.com/kinnala/scikit-fem/blob/master/docs/examples/ex01.py>`_ for more information.
 
+.. _ex07:
 
 Example 7: Discontinuous Galerkin method
 ----------------------------------------

--- a/skfem/assembly/basis/abstract_basis.py
+++ b/skfem/assembly/basis/abstract_basis.py
@@ -418,10 +418,6 @@ class AbstractBasis:
         """Create a copy of ``self`` that uses different element."""
         raise NotImplementedError
 
-    def project(self, rhs, **kwargs):
-        """Perform :math:`L^2` projection onto the basis.
-
-        Solves the variational problem ``inner(u, v) = inner(rhs(w), v)``.
-
-        """
+    def project(self, interp, **kwargs):
+        """Perform :math:`L^2` projection onto the basis."""
         raise NotImplementedError

--- a/skfem/assembly/basis/abstract_basis.py
+++ b/skfem/assembly/basis/abstract_basis.py
@@ -435,5 +435,4 @@ class AbstractBasis:
         )
 
     def project(self, interp, **kwargs):
-        """Perform :math:`L^2` projection onto the basis."""
         raise NotImplementedError

--- a/skfem/assembly/basis/abstract_basis.py
+++ b/skfem/assembly/basis/abstract_basis.py
@@ -417,3 +417,11 @@ class AbstractBasis:
     def with_element(self, elem: Element) -> 'AbstractBasis':
         """Create a copy of ``self`` that uses different element."""
         raise NotImplementedError
+
+    def project(self, rhs, **kwargs):
+        """Perform :math:`L^2` projection onto the basis.
+
+        Solves the variational problem ``inner(u, v) = inner(rhs(w), v)``.
+
+        """
+        raise NotImplementedError

--- a/skfem/assembly/basis/abstract_basis.py
+++ b/skfem/assembly/basis/abstract_basis.py
@@ -418,6 +418,22 @@ class AbstractBasis:
         """Create a copy of ``self`` that uses different element."""
         raise NotImplementedError
 
+    def _projection(self, interp):
+
+        from skfem.assembly import BilinearForm, LinearForm
+        from skfem.helpers import inner
+
+        if isinstance(interp, float):
+            interp = interp + self.global_coordinates().value[0] * 0.
+
+        if callable(interp):
+            interp = interp(self.global_coordinates().value)
+
+        return (
+            BilinearForm(lambda u, v, _: inner(u, v)).assemble(self),
+            LinearForm(lambda v, w: inner(interp, v)).assemble(self),
+        )
+
     def project(self, interp, **kwargs):
         """Perform :math:`L^2` projection onto the basis."""
         raise NotImplementedError

--- a/skfem/assembly/basis/boundary_facet_basis.py
+++ b/skfem/assembly/basis/boundary_facet_basis.py
@@ -215,7 +215,7 @@ class BoundaryFacetBasis(AbstractBasis):
             facets=self.find,
         )
 
-    def project(self, interp, facets=None,**kwargs):
+    def project(self, interp, facets=None):
         from skfem.helpers import inner
         from skfem.utils import solve
         from skfem.assembly import BilinearForm, LinearForm

--- a/skfem/assembly/basis/boundary_facet_basis.py
+++ b/skfem/assembly/basis/boundary_facet_basis.py
@@ -216,19 +216,10 @@ class BoundaryFacetBasis(AbstractBasis):
         )
 
     def project(self, interp, facets=None):
-        from skfem.helpers import inner
-        from skfem.utils import solve
-        from skfem.assembly import BilinearForm, LinearForm
-        from skfem.utils import condense
 
-        if isinstance(interp, float):
-            interp = interp + self.global_coordinates().value[0] * 0.
+        from skfem.utils import solve, condense
 
-        if callable(interp):
-            interp = interp(self.global_coordinates().value)
-
-        M = BilinearForm(lambda u, v, _: inner(u, v)).assemble(self)
-        f = LinearForm(lambda v, w: inner(interp, v)).assemble(self)
+        M, f = self._projection(interp)
 
         if facets is not None:
             return solve(*condense(M, f, I=self.get_dofs(facets=facets)))

--- a/skfem/assembly/basis/boundary_facet_basis.py
+++ b/skfem/assembly/basis/boundary_facet_basis.py
@@ -228,7 +228,7 @@ class BoundaryFacetBasis(AbstractBasis):
             interp = interp(self.global_coordinates().value)
 
         M = BilinearForm(lambda u, v, _: inner(u, v)).assemble(self)
-        f = LinearForm(lambda v, w: inner(interp, v)).assemble(self, **kwargs)
+        f = LinearForm(lambda v, w: inner(interp, v)).assemble(self)
 
         if facets is not None:
             return solve(*condense(M, f, I=self.get_dofs(facets=facets)))

--- a/skfem/assembly/basis/boundary_facet_basis.py
+++ b/skfem/assembly/basis/boundary_facet_basis.py
@@ -216,7 +216,23 @@ class BoundaryFacetBasis(AbstractBasis):
         )
 
     def project(self, interp, facets=None):
+        """Perform :math:`L^2` projection onto the basis on the boundary.
 
+        The values of the interior DOFs remain zero.
+
+        Parameters
+        ----------
+        interp
+            An object of type :class:`~skfem.element.DiscreteField` which is a
+            function (to be projected) evaluated at global quadrature points at
+            the boundary of the domain.  If a function is given, then
+            :class:`~skfem.element.DiscreteField` is created by passing
+            an array of global quadrature point locations to the function.
+        facets
+            Optionally perform the projection on a subset of facets.  The
+            values of the remaining DOFs are zero.
+
+        """
         from skfem.utils import solve, condense
 
         M, f = self._projection(interp)

--- a/skfem/assembly/basis/cell_basis.py
+++ b/skfem/assembly/basis/cell_basis.py
@@ -221,7 +221,7 @@ class CellBasis(AbstractBasis):
             interp = interp(self.global_coordinates().value)
 
         M = BilinearForm(lambda u, v, _: inner(u, v)).assemble(self)
-        f = LinearForm(lambda v, w: inner(interp, v)).assemble(self, **kwargs)
+        f = LinearForm(lambda v, w: inner(interp, v)).assemble(self)
 
         if elements is not None:
             return solve(*condense(M, f, I=self.get_dofs(elements=elements)))

--- a/skfem/assembly/basis/cell_basis.py
+++ b/skfem/assembly/basis/cell_basis.py
@@ -209,7 +209,21 @@ class CellBasis(AbstractBasis):
         )
 
     def project(self, interp, elements=None):
+        """Perform :math:`L^2` projection onto the basis.
 
+        Parameters
+        ----------
+        interp
+            An object of type :class:`~skfem.element.DiscreteField` which is a
+            function (to be projected) evaluated at global quadrature points.
+            If a function is given, then :class:`~skfem.element.DiscreteField`
+            is created by passing an array of global quadrature point locations
+            to the function.
+        elements
+            Optionally perform the projection on a subset of elements.  The
+            values of the remaining DOFs are zero.
+
+        """
         from skfem.utils import solve, condense
 
         M, f = self._projection(interp)

--- a/skfem/assembly/basis/cell_basis.py
+++ b/skfem/assembly/basis/cell_basis.py
@@ -208,7 +208,7 @@ class CellBasis(AbstractBasis):
             elements=self.tind,
         )
 
-    def project(self, interp, elements=None, **kwargs):
+    def project(self, interp, elements=None):
         from skfem.helpers import inner
         from skfem.utils import solve
         from skfem.assembly import BilinearForm, LinearForm

--- a/skfem/assembly/basis/cell_basis.py
+++ b/skfem/assembly/basis/cell_basis.py
@@ -211,6 +211,8 @@ class CellBasis(AbstractBasis):
     def project(self, interp, elements=None):
         """Perform :math:`L^2` projection onto the basis.
 
+        See :ref:`l2proj` for more information.
+
         Parameters
         ----------
         interp

--- a/skfem/assembly/basis/cell_basis.py
+++ b/skfem/assembly/basis/cell_basis.py
@@ -209,19 +209,10 @@ class CellBasis(AbstractBasis):
         )
 
     def project(self, interp, elements=None):
-        from skfem.helpers import inner
-        from skfem.utils import solve
-        from skfem.assembly import BilinearForm, LinearForm
-        from skfem.utils import condense
 
-        if isinstance(interp, float):
-            interp = interp + self.global_coordinates().value[0] * 0.
+        from skfem.utils import solve, condense
 
-        if callable(interp):
-            interp = interp(self.global_coordinates().value)
-
-        M = BilinearForm(lambda u, v, _: inner(u, v)).assemble(self)
-        f = LinearForm(lambda v, w: inner(interp, v)).assemble(self)
+        M, f = self._projection(interp)
 
         if elements is not None:
             return solve(*condense(M, f, I=self.get_dofs(elements=elements)))

--- a/skfem/assembly/form/coo_data.py
+++ b/skfem/assembly/form/coo_data.py
@@ -88,7 +88,7 @@ class COOData:
         )
 
     def toarray(self) -> ndarray:
-        """Return a dense NumPy array."""
+        """Return a dense numpy array."""
         if len(self.shape) == 1:
             return coo_matrix(
                 (self.data, (self.indices[0], np.zeros_like(self.indices[0]))),

--- a/skfem/element/__init__.py
+++ b/skfem/element/__init__.py
@@ -13,6 +13,7 @@ from .element import Element
 from .element_h1 import ElementH1
 from .element_hdiv import ElementHdiv
 from .element_hcurl import ElementHcurl
+from .element_global import ElementGlobal
 from .element_vector import ElementVector
 from .element_tri import (ElementTriP1, ElementTriP2,  # noqa
                           ElementTriP0, ElementTriRT0, ElementTriMorley,
@@ -69,6 +70,7 @@ __all__ = [
     "ElementVectorH1",
     "ElementHdiv",
     "ElementHcurl",
+    "ElementGlobal",
     "ElementDG",
     "ElementComposite",
     "ElementTriP1",

--- a/skfem/element/element_tri/element_tri_skeleton_p0.py
+++ b/skfem/element/element_tri/element_tri_skeleton_p0.py
@@ -5,6 +5,7 @@ import numpy as np
 
 
 class ElementTriSkeletonP0(ElementH1):
+    """Constant element for the mesh skeleton."""
 
     facet_dofs = 1
     maxdeg = 0

--- a/skfem/element/element_tri/element_tri_skeleton_p1.py
+++ b/skfem/element/element_tri/element_tri_skeleton_p1.py
@@ -5,6 +5,7 @@ import numpy as np
 
 
 class ElementTriSkeletonP1(ElementH1):
+    """Linear element for the mesh skeleton."""
 
     facet_dofs = 2
     maxdeg = 1

--- a/skfem/element/element_vector.py
+++ b/skfem/element/element_vector.py
@@ -4,6 +4,7 @@ from .discrete_field import DiscreteField
 
 
 class ElementVector(Element):
+    """Use the same element for each dimension."""
 
     def __init__(self, elem, dim=None):
         self.elem = elem

--- a/skfem/helpers.py
+++ b/skfem/helpers.py
@@ -94,6 +94,23 @@ def dddd(u: DiscreteField):
     return u.grad4
 
 
+def inner(u: FieldOrArray, v: FieldOrArray):
+    """Inner product between any matching tensors."""
+    if isinstance(u, DiscreteField) and u.is_zero():
+        return u
+    if isinstance(v, DiscreteField) and v.is_zero():
+        return v
+    U = u.value if isinstance(u, DiscreteField) else u
+    V = v.value if isinstance(v, DiscreteField) else v
+    if len(U.shape) == 2:
+        return U * V
+    elif len(U.shape) == 3:
+        return dot(U, V)
+    elif len(U.shape) == 4:
+        return ddot(U, V)
+    raise NotImplementedError
+
+
 def dot(u: FieldOrArray, v: FieldOrArray):
     """Dot product."""
     if isinstance(u, DiscreteField) and u.is_zero():

--- a/skfem/helpers.py
+++ b/skfem/helpers.py
@@ -74,21 +74,21 @@ def sym_grad(u: DiscreteField):
 
 
 def dd(u: DiscreteField):
-    """Hessian (if available)."""
+    """Hessian (for :class:`~skfem.element.ElementGlobal`)."""
     if u.is_zero():
         return u
     return u.hess
 
 
 def ddd(u: DiscreteField):
-    """Third derivative (if available)."""
+    """Third derivative (for :class:`~skfem.element.ElementGlobal`)."""
     if u.is_zero():
         return u
     return u.grad3
 
 
 def dddd(u: DiscreteField):
-    """Fourth derivative (if available)."""
+    """Fourth derivative (for :class:`~skfem.element.ElementGlobal`)."""
     if u.is_zero():
         return u
     return u.grad4
@@ -198,21 +198,7 @@ def identity(w, N=None):
 
 
 def det(A):
-    """
-    Determinant of an array `A` over trailing axis (if any).
-
-    Parameters
-    ----------
-    A : (N, N,...) numpy.ndarray
-        N = 2 or 3
-        Input array whose determinant is to be computed
-
-    Returns
-    -------
-    det : (...) numpy.ndarray
-        Determinant of `A`.
-
-    """
+    """Determinant of an array `A` over trailing axis (if any)."""
     detA = zeros_like(A[0, 0])
     if A.shape[0] == 3:
         detA = A[0, 0] * (A[1, 1] * A[2, 2] -
@@ -227,20 +213,7 @@ def det(A):
 
 
 def inv(A):
-    """Inverse of an array `A` over trailing axis (if any)
-
-    Parameters
-    ----------
-    A : (N, N,...) numpy.ndarray
-        N = 2 or 3
-        Input array whose inverse is to be computed
-
-    Returns
-    -------
-    Ainv : (N, N,...) numpy.ndarray
-        Inverse of `A`.
-
-    """
+    """Inverse of an array `A` over trailing axis (if any)."""
     invA = zeros_like(A)
     detA = det(A)
     if A.shape[0] == 3:

--- a/skfem/models/poisson.py
+++ b/skfem/models/poisson.py
@@ -5,20 +5,20 @@ from skfem.helpers import grad, dot, ddot
 
 
 @BilinearForm
-def laplace(u, v, w):
+def laplace(u, v, _):
     return dot(grad(u), grad(v))
 
 
 @BilinearForm
-def vector_laplace(u, v, w):
+def vector_laplace(u, v, _):
     return ddot(grad(u), grad(v))
 
 
 @BilinearForm
-def mass(u, v, w):
+def mass(u, v, _):
     return u * v
 
 
 @LinearForm
-def unit_load(v, w):
+def unit_load(v, _):
     return v

--- a/skfem/visuals/matplotlib.py
+++ b/skfem/visuals/matplotlib.py
@@ -9,7 +9,7 @@ import matplotlib.pyplot as plt
 from matplotlib.axes import Axes
 
 from ..assembly import CellBasis
-from ..mesh import Mesh2D, MeshLine1, MeshQuad1, MeshTet1, MeshTri1
+from ..mesh import Mesh2D, MeshLine1, MeshQuad1, MeshTet1, MeshTri1, MeshHex1
 
 
 @singledispatch
@@ -38,6 +38,23 @@ def draw_meshtet(m: MeshTet1, **kwargs) -> Axes:
     indexing = m.facets[:, bnd_facets].T
     ax.plot_trisurf(m.p[0], m.p[1], m.p[2],
                     triangles=indexing, cmap=plt.cm.viridis, edgecolor='k')
+    ax.set_axis_off()
+    ax.show = lambda: plt.show()
+    return ax
+
+
+@draw.register(MeshHex1)
+def draw_meshhex(m: MeshHex1, **kwargs) -> Axes:
+    """Visualize a hexahedral mesh by drawing the edges."""
+    ax = plt.figure().add_subplot(1, 1, 1, projection='3d')
+    for ix in range(m.edges.shape[1]):
+        ax.plot3D(
+            m.p[0, m.edges[:, ix]].flatten(),
+            m.p[1, m.edges[:, ix]].flatten(),
+            m.p[2, m.edges[:, ix]].flatten(),
+            kwargs['color'] if 'color' in kwargs else 'k',
+            linewidth=kwargs['linewidth'] if 'linewidth' in kwargs else .5,
+        )
     ax.set_axis_off()
     ax.show = lambda: plt.show()
     return ax


### PR DESCRIPTION
L2 projection is a fairly simple concept but it gets tedious to write the same forms over and over again. Because projections are so common it makes sense to have it available as an utility inside the library to save some typing.

`L2_projection` turned into `project` turned into `projection` and tried to be the utility but it became complex and still didn't do everything we need. Moreover, judging by the examples it really didn't even do its existing job well.

After thinking about #816, I wondered what if it really was just the inverse of `basis.interpolate()`?
```python
>>> from skfem import *
>>> m = MeshTri()
>>> basis = Basis(m, ElementTriP1())
>>> y = m.p[1]
>>> (basis.project(basis.interpolate(y)) - y).sum()
-1.3877787807814457e-16
```
So here `basis.project()` takes in `y` as `DiscreteField` and solves the variational problem `(u, v) = (y, v)`. Super simple, only few lines of code.

Then I added a convenient shortcut: if the parameter is callable, then `basis.project()` will pass in the global quadrature points to create `y`:
```python
>>> basis.project(lambda x: x[0] ** 2)
array([-0.11111111,  0.80555556, -0.19444444,  0.88888889])
```
Gradient-averaged derivative is short and sweet:
```python
>>> basis.project(basis.interpolate(m.p[0]).grad[0])
array([1., 1., 1., 1.])
```
Real derivative is not much longer, you just need to initialize the P0 basis:
```python
>>> basis0 = basis.with_element(ElementTriP0())
>>> basis0.project(basis.interpolate(m.p[0]).grad[0])
array([1., 1.])
```
Using `FacetBasis` it will do `solve` only on the boundary DOFs and extend by zero in the interior (which is what you usually want to do, see changes to `howto.rst`.)

I feel this is finally going somewhere, and judging by the respective changes to the examples it really simplifies things.