### PR TITLE
avoid DeprecationWarning in ex24.D

### DIFF
--- a/docs/examples/ex24.py
+++ b/docs/examples/ex24.py
@@ -29,7 +29,7 @@ element = {'u': ElementVector(ElementTriP2()),
 basis = {variable: Basis(mesh, e, intorder=3)
          for variable, e in element.items()}
 
-D = basis['u'].get_dofs(mesh.boundaries)
+D = basis['u'].get_dofs(['inlet', 'ceiling', 'floor'])
 
 A = asm(vector_laplace, basis['u'])
 B = -asm(divergence, basis['u'], basis['p'])

--- a/docs/examples/ex24.py
+++ b/docs/examples/ex24.py
@@ -29,7 +29,7 @@ element = {'u': ElementVector(ElementTriP2()),
 basis = {variable: Basis(mesh, e, intorder=3)
          for variable, e in element.items()}
 
-D = basis['u'].get_dofs(['inlet', 'ceiling', 'floor'])
+D = basis['u'].get_dofs(mesh.boundaries)
 
 A = asm(vector_laplace, basis['u'])
 B = -asm(divergence, basis['u'], basis['p'])


### PR DESCRIPTION
When I ran `pytest tests` locally during #831, I noticed a couple of minor glitches including

```
tests/test_examples.py::TestEx24::runTest
  /home/gdmcbain/src/scikit-fem/skfem/assembly/basis/abstract_basis.py:227: DeprecationWarning: Passing dict to get_dofs is deprecated.
    warn("Passing dict to get_dofs is deprecated.", DeprecationWarning)
```