### PR TITLE
avoid DeprecationWarning from union of Dofs

### DIFF
--- a/docs/examples/ex24.py
+++ b/docs/examples/ex24.py
@@ -29,7 +29,7 @@ element = {'u': ElementVector(ElementTriP2()),
 basis = {variable: Basis(mesh, e, intorder=3)
          for variable, e in element.items()}
 
-D = basis['u'].get_dofs(mesh.boundaries)
+D = basis['u'].get_dofs(['inlet', 'ceiling', 'floor'])
 
 A = asm(vector_laplace, basis['u'])
 B = -asm(divergence, basis['u'], basis['p'])

--- a/docs/examples/ex24.py
+++ b/docs/examples/ex24.py
@@ -29,7 +29,7 @@ element = {'u': ElementVector(ElementTriP2()),
 basis = {variable: Basis(mesh, e, intorder=3)
          for variable, e in element.items()}
 
-D = basis['u'].get_dofs(['inlet', 'ceiling', 'floor'])
+D = basis['u'].get_dofs(mesh.boundaries)
 
 A = asm(vector_laplace, basis['u'])
 B = -asm(divergence, basis['u'], basis['p'])

--- a/tests/test_dofs.py
+++ b/tests/test_dofs.py
@@ -95,7 +95,9 @@ class TestDofsFromBoundaries(TestCase):
         basis = CellBasis(m, ElementTriArgyris())
         assert_allclose(
             basis.get_dofs({'left', 'right'}).all(),
-            (basis.get_dofs('left') | basis.get_dofs('right')).all(),
+            np.sort(
+                np.hstack([basis.get_dofs('left').all(), basis.get_dofs('right').all()])
+            ),
         )
         assert_allclose(
             basis.get_dofs(('left', 'right', 'top', 'bottom')).all(),


### PR DESCRIPTION
The deprecation doesn't say what to do instead of union, but stacking and sorting passes the test.