### PR TITLE
Mean not sum

### DIFF
--- a/docs/examples/ex24.py
+++ b/docs/examples/ex24.py
@@ -29,7 +29,7 @@ element = {'u': ElementVector(ElementTriP2()),
 basis = {variable: Basis(mesh, e, intorder=3)
          for variable, e in element.items()}
 
-D = basis['u'].get_dofs(mesh.boundaries)
+D = basis['u'].get_dofs(['inlet', 'ceiling', 'floor'])
 
 A = asm(vector_laplace, basis['u'])
 B = -asm(divergence, basis['u'], basis['p'])

--- a/docs/examples/ex24.py
+++ b/docs/examples/ex24.py
@@ -29,7 +29,7 @@ element = {'u': ElementVector(ElementTriP2()),
 basis = {variable: Basis(mesh, e, intorder=3)
          for variable, e in element.items()}
 
-D = basis['u'].get_dofs(['inlet', 'ceiling', 'floor'])
+D = basis['u'].get_dofs(mesh.boundaries)
 
 A = asm(vector_laplace, basis['u'])
 B = -asm(divergence, basis['u'], basis['p'])

--- a/skfem/mesh/mesh.py
+++ b/skfem/mesh/mesh.py
@@ -296,8 +296,7 @@ class Mesh:
             If ``True``, include only boundary facets.
 
         """
-        midp = [np.sum(self.p[itr, self.facets], axis=0) / self.facets.shape[0]
-                for itr in range(self.dim())]
+        midp = self.p[:, self.facets].mean(axis=1)
         facets = np.nonzero(test(np.array(midp)))[0]
         if boundaries_only:
             facets = np.intersect1d(facets, self.boundary_facets())
@@ -314,8 +313,7 @@ class Mesh:
             are to be included in the return set.
 
         """
-        midp = [np.sum(self.p[itr, self.t], axis=0) / self.t.shape[0]
-                for itr in range(self.dim())]
+        midp = self.p[:, self.t].mean(axis=1)
         return np.nonzero(test(np.array(midp)))[0]
 
     def _expand_facets(self, ix: ndarray) -> Tuple[ndarray, ndarray]:

--- a/skfem/mesh/mesh.py
+++ b/skfem/mesh/mesh.py
@@ -297,7 +297,7 @@ class Mesh:
 
         """
         midp = self.p[:, self.facets].mean(axis=1)
-        facets = np.nonzero(test(np.array(midp)))[0]
+        facets = np.nonzero(test(midp))[0]
         if boundaries_only:
             facets = np.intersect1d(facets, self.boundary_facets())
         return facets
@@ -314,7 +314,7 @@ class Mesh:
 
         """
         midp = self.p[:, self.t].mean(axis=1)
-        return np.nonzero(test(np.array(midp)))[0]
+        return np.nonzero(test(midp))[0]
 
     def _expand_facets(self, ix: ndarray) -> Tuple[ndarray, ndarray]:
         """Return vertices and edges corresponding to given facet indices.


### PR DESCRIPTION
Instead of summing and dividing by the count, one can just use the `numpy.ndarray.mean` method.  This also obviates the list-comprehension and subsequent cast back to array.

I noticed this while admiring [the latest clever side-effect](https://github.com/kinnala/scikit-fem/discussions/824#discussioncomment-1885560) in #824 .