### PR TITLE
Add standard hyperelasticity example

### DIFF
--- a/docs/examples/ex21.py
+++ b/docs/examples/ex21.py
@@ -91,6 +91,5 @@ L, x = solve(
 
 if __name__ == "__main__":
     from skfem.visuals.matplotlib import draw, show
-    sf = 2.0
-    draw(MeshTet(np.array(m.p + sf * x[ib.nodal_dofs, 0]), m.t))
-    show()
+    sf = 10.0
+    m.translated(sf * x[ib.nodal_dofs, 0]).draw().show()

--- a/docs/examples/ex43.py
+++ b/docs/examples/ex43.py
@@ -1,0 +1,167 @@
+r"""Hyperelasticity.
+
+The strain energy density function per unit undeformed volume of the
+isotropic hyperelastic Neo-Hookean material formulation is given as
+
+..  math::
+
+    \psi(\boldsymbol{F}) = \frac{\mu}{2} ( I_1 - 3) - \mu \ln(J) +
+    \frac{\lambda}{2} \ln^2(J)
+
+
+by the first invariant of the right Cauchy-Green deformation tensor
+and the determinant of the deformation gradient (volume change).
+
+..  math::
+
+    I_1 &= \text{tr}(\boldsymbol{F}^T \boldsymbol{F}) =
+    \boldsymbol{F} : \boldsymbol{F}
+
+    J &= \det(\boldsymbol{F})
+
+
+The variation of the strain energy function leads to
+
+..  math::
+
+    \delta\psi(\boldsymbol{F}) = \frac{\mu}{2} \delta I_1 - \mu \delta\ln(J)
+    + \lambda \ln(J) \delta\ln(J)
+
+
+with
+
+..  math::
+
+    \delta I_1 &= 2 \boldsymbol{F} : \delta\boldsymbol{F}
+
+    \delta \ln(J) &= \boldsymbol{F}^{-T} : \delta\boldsymbol{F}
+
+
+which finally results in
+
+..  math::
+
+    \delta\psi(\boldsymbol{F}) = \mu \boldsymbol{F} : \delta\boldsymbol{F} -
+    (\lambda \ln(J) - \mu) \boldsymbol{F}^{-T} : \delta\boldsymbol{F}
+
+The linearization of the variation leads to
+
+..  math::
+
+    \Delta\delta\psi(\boldsymbol{F}) = \mu \Delta\boldsymbol{F} :
+    \delta\boldsymbol{F} + (\lambda \ln(J) - \mu)
+    \Delta\boldsymbol{F}^{-T} : \delta\boldsymbol{F}
+    + \lambda \left( \boldsymbol{F}^{-T} : \delta\boldsymbol{F} \right)
+    \left( \boldsymbol{F}^{-T} : \Delta\boldsymbol{F} \right)
+
+with
+
+..  math::
+
+    \Delta\boldsymbol{F}^{-T} = -\boldsymbol{F}^{-T} \Delta\boldsymbol{F}^{T}
+    \boldsymbol{F}^{-T}
+
+which may be alternatively formulated by expressions of the trace:
+
+..  math::
+
+    \Delta\delta\psi(\boldsymbol{F}) = \mu \Delta\boldsymbol{F} :
+    \delta\boldsymbol{F} + (\lambda \ln(J) - \mu)
+        \text{tr}(\Delta\boldsymbol{F} \boldsymbol{F}^{-1}
+                  \delta\boldsymbol{F} \boldsymbol{F}^{-1})
+    + \lambda \text{tr}(\delta\boldsymbol{F} \boldsymbol{F}^{-1})
+        \text{tr}(\Delta\boldsymbol{F} \boldsymbol{F}^{-1})
+
+"""
+import numpy as np
+
+from skfem import *
+from skfem.helpers import grad, identity, ddot, det, transpose, inv, trace, mul
+
+# note: rough mesh to make tests fast
+mesh = MeshHex.init_tensor(
+    np.linspace(0, 1, 10),
+    np.linspace(-.1, .1, 3),
+    np.linspace(-.1, .1, 3),
+).with_boundaries({
+    'left': lambda x: x[0] == 0.,
+    'right': lambda x: x[0] == 1.,
+})
+element = ElementVector(ElementHex1())
+basis = Basis(mesh, element, intorder=1)
+
+mu, lmbda = 1., 2.
+
+def deformation_gradient(w):
+    dudX = grad(w["displacement"])
+    F = dudX + identity(dudX)
+    return F, inv(F)
+
+@LinearForm
+def L(v, w):
+    F, iF = deformation_gradient(w)
+    dF = grad(v)
+    lnJ = np.log(det(F))
+    return mu * ddot(F, dF) + (lmbda * lnJ - mu) * ddot(transpose(iF), dF)
+
+@BilinearForm
+def a(u, v, w):
+    F, iF = deformation_gradient(w)
+    DF = grad(u)
+    dF = grad(v)
+    dFiF = mul(dF, iF)
+    DFiF = mul(DF, iF)
+    tr_DFiF_dFiF = ddot(transpose(dFiF), DFiF)
+    lnJ = np.log(det(F))
+    return (mu * ddot(DF, dF) - (lmbda * lnJ - mu) * tr_DFiF_dFiF
+            + lmbda * trace(dFiF) * trace(DFiF))
+
+u  = basis.zeros()
+du = basis.zeros()
+uv = basis.interpolate(u)
+
+dofs = basis.get_dofs('right')
+dirichlet = basis.get_dofs({'right', 'left'})
+
+f = L.assemble(basis, displacement=uv)
+K = a.assemble(basis, displacement=uv)
+
+right = -0.1
+tol = 1e-10
+nsteps = 7
+
+for step in range(nsteps):
+    for iteration in range(10):
+        c = (step + 1.) / nsteps
+
+        du_D = u.copy()
+        x, y, z = basis.doflocs[:, dofs.nodal['u^1']]
+        du_D[dofs.nodal['u^1']] = c * right - du_D[dofs.nodal['u^1']]
+        du_D[dofs.nodal['u^2']] = (
+            y * np.cos(c * np.pi) - z * np.sin(c * np.pi) - y
+            - du_D[dofs.nodal['u^2']]
+        )
+        du_D[dofs.nodal['u^3']] = (
+            y * np.sin(c * np.pi) + z * np.cos(c * np.pi) - z
+            - du_D[dofs.nodal['u^3']]
+        )
+
+        du = solve(*condense(K, -f, x=du_D, D=dirichlet))
+        norm_du = np.linalg.norm(du)
+        u += du
+
+        uv = basis.interpolate(u)
+
+        f = L.assemble(basis, displacement=uv)
+        K = a.assemble(basis, displacement=uv)
+
+        print(1 + iteration, norm_du)
+
+        if norm_du < tol:
+            break
+
+
+if __name__ == '__main__':
+    (mesh.translated(u[basis.nodal_dofs])
+         .draw(point_data={'uy': u[basis.nodal_dofs[1]]})
+         .show())

--- a/docs/listofexamples.rst
+++ b/docs/listofexamples.rst
@@ -264,9 +264,9 @@ Example 21: Structural vibration
 This example demonstrates the solution of a three-dimensional vector-valued
 eigenvalue problem by considering the vibration of an elastic structure.
 
-.. figure:: https://user-images.githubusercontent.com/973268/87779087-ebe92080-c834-11ea-9acc-d455b6124ad7.png
+.. figure:: https://user-images.githubusercontent.com/973268/147790554-4b768d43-25fa-49cd-ab19-b16a199a6459.png
 
-   An eigenmode of Example 21.
+   The first eigenmode of Example 21.
 
 See the `source code of Example 21 <https://github.com/kinnala/scikit-fem/blob/master/docs/examples/ex21.py>`_ for more information.
 
@@ -305,7 +305,7 @@ Example 43: Hyperelasticity
 This example demonstrates Newton's method applied to the classical formulation
 of a hyperelastic Neo-Hookean solid.
 
-.. figure:: https://user-images.githubusercontent.com/973268/147789791-544e39f2-3160-469b-a79b-b30a9c3155c0.png
+.. figure:: https://user-images.githubusercontent.com/973268/147790182-64f4abf4-3909-4ec0-89ac-2add304b133d.png
 
    The deformed mesh of Example 43.
    The figure was created using `vedo <https://github.com/marcomusy/vedo>`__.

--- a/docs/listofexamples.rst
+++ b/docs/listofexamples.rst
@@ -298,6 +298,20 @@ for nearly incompressible Neo-Hookean solids.
 
 See the `source code of Example 36 <https://github.com/kinnala/scikit-fem/blob/master/docs/examples/ex36.py>`_ for more information.
 
+
+Example 43: Hyperelasticity
+---------------------------
+
+This example demonstrates Newton's method applied to the classical formulation
+of a hyperelastic Neo-Hookean solid.
+
+.. figure:: https://user-images.githubusercontent.com/973268/147789791-544e39f2-3160-469b-a79b-b30a9c3155c0.png
+
+   The deformed mesh of Example 43.
+   The figure was created using `vedo <https://github.com/marcomusy/vedo>`__.
+
+See the `source code of Example 43 <https://github.com/kinnala/scikit-fem/blob/master/docs/examples/ex43.py>`_ for more information.
+
 Fluid mechanics
 ===============
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -364,3 +364,11 @@ class TestEx42(TestCase):
         import docs.examples.ex42 as ex
 
         self.assertAlmostEqual(ex.x.max(), 0.0009824131638261542, delta=1e-5)
+
+
+class TestEx43(TestCase):
+
+    def runTest(self):
+        import docs.examples.ex43 as ex
+
+        self.assertAlmostEqual(ex.u.max(), 0.2466622622014594, delta=1e-8)


### PR DESCRIPTION
Example 36 includes two field formulation of incompressible hyperelasticity. This is an example of the classical approach to hyperelasticity by @adtzlr from #839.