### PR TITLE
Make DiscreteField subclass ndarray

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,11 +215,14 @@ with respect to documented and/or tested features.
 
 ### Unreleased
 
+- Changed: `DiscreteField` is now a subclass of `ndarray` instead of
+  `NamedTuple`
 - Changed: `Mesh.draw` now uses `matplotlib` by default, call
   `Mesh.draw("vedo")` to use `vedo`
 - Changed: `skfem.visuals.matplotlib` uses now `jet` as the default colormap
 - Added: `Mesh.plot`, a wrapper to `skfem.visuals.*.plot`
 - Added: `Basis.plot`, a wrapper to `skfem.visuals.*.plot`
+- Added: `Basis.refinterp` now supports vectorial fields
 - Fixed: Improvements to backwards compatibility in `asm`/`assemble` kwargs
 
 ### [5.2.0] - 2021-12-27
@@ -244,7 +247,6 @@ with respect to documented and/or tested features.
 
 - Changed: `meshio` is now an optional dependency
 - Changed: `ElementComposite` uses `DiscreteField()` to represent zero
-- Changed: Better string `__repr__` for `Basis` and `DofsView`
 - Added: Support more argument types in `Basis.get_dofs`
 - Added: Version information in `skfem.__version__`
 - Added: Preserve `Mesh.boundaries` during uniform refinement of `MeshLine1`,

--- a/README.md
+++ b/README.md
@@ -217,12 +217,18 @@ with respect to documented and/or tested features.
 
 - Changed: `DiscreteField` is now a subclass of `ndarray` instead of
   `NamedTuple`
+- Changed: Writing `w['u']` and `w.u` inside the form definition is now
+  equivalent (previously `w.u == w['u'].value`)
 - Changed: `Mesh.draw` now uses `matplotlib` by default, call
-  `Mesh.draw("vedo")` to use `vedo`
-- Changed: `skfem.visuals.matplotlib` uses now `jet` as the default colormap
+  `Mesh.draw("vedo")` to keep using `vedo`
+- Changed: `skfem.visuals.matplotlib` now uses `jet` as the default colormap
+- Deprecated: `DiscreteField.value` remains for backwards-compatibility but is
+  now deprecated and can be dropped
 - Added: `Mesh.plot`, a wrapper to `skfem.visuals.*.plot`
 - Added: `Basis.plot`, a wrapper to `skfem.visuals.*.plot`
 - Added: `Basis.refinterp` now supports vectorial fields
+- Added: `skfem.visuals.matpltlib.plot` now has a basic quiver plot for vector
+  fields
 - Fixed: Improvements to backwards compatibility in `asm`/`assemble` kwargs
 
 ### [5.2.0] - 2021-12-27

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -60,7 +60,7 @@ This can be written as
 
    The last argument ``w`` is a dictionary of
    :class:`~skfem.element.DiscreteField` objects.  Its ``_getattr_`` is
-   overridden so that ``w.x`` corresponds to ``w['x'].value``.  Some keys are
+   overridden so that ``w.x`` corresponds to ``w['x']``.  Some keys are
    populated by default, e.g., ``w.x`` are the global quadrature points.
 
 In addition, forms can depend on the local mesh parameter ``w.h`` or other
@@ -113,24 +113,8 @@ elements` x `number of quadrature points per element`.  The return value should
 always have such shape no matter which mesh or element type is used.
 
 The module :mod:`skfem.helpers` contains functions that make the forms more
-readable.  An alternative way to write the above form is
-
-.. doctest:: python
-
-   >>> from skfem import BilinearForm
-   >>> @BilinearForm
-   ... def integrand(u, v, w):
-   ...     return u[1][0] * v[1][0] + u[1][1] * v[1][1]
-
-.. note::
-
-    In fact, ``u`` and ``v`` are simply named tuples of numpy arrays with the
-    values of the function at ``u[0]`` or ``u.value`` and the values of the
-    gradient at ``u[1]`` or ``u.grad`` (and some additional magic such as
-    implementing ``__array__`` and ``__mul__`` so that expressions such as
-    ``u * v`` work as expected).
-
-Notice how the shape of ``u[0]`` is what we expect also from the return value:
+readable.  Notice how the shape of ``u.grad[0]`` is what we expect also from
+the return value:
 
 .. code-block:: none
 
@@ -138,7 +122,7 @@ Notice how the shape of ``u[0]`` is what we expect also from the return value:
    >>> asm(integrand, Basis(MeshTri(), ElementTriP1()))
    > /home/tom/src/scikit-fem/test.py(7)integrand()
    -> return dot(grad(u), grad(v))
-   (Pdb) !u[0]
+   (Pdb) !u.grad[0]
    array([[0.66666667, 0.16666667, 0.16666667],
           [0.66666667, 0.16666667, 0.16666667]])
 

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -188,7 +188,7 @@ cube mesh:
    <skfem CellBasis(MeshHex1, ElementHex2) object>
      Number of elements: 1
      Number of DOFs: 27
-     Size: 296352 B
+     Size: 74088 B
 
 .. plot::
 

--- a/docs/examples/ex11.py
+++ b/docs/examples/ex11.py
@@ -12,7 +12,7 @@ from skfem.models.elasticity import linear_elasticity, lame_parameters
 
 m = MeshHex().refined(3)
 e1 = ElementHex1()
-e = ElementVectorH1(e1)
+e = ElementVector(e1)
 ib = Basis(m, e, MappingIsoparametric(m, e1), 3)
 
 K = asm(linear_elasticity(*lame_parameters(1e3, 0.3)), ib)

--- a/docs/examples/ex18.py
+++ b/docs/examples/ex18.py
@@ -53,7 +53,7 @@ from scipy.sparse import bmat
 
 mesh = MeshTri.init_circle(4)
 
-element = {'u': ElementVectorH1(ElementTriP2()),
+element = {'u': ElementVector(ElementTriP2()),
            'p': ElementTriP1()}
 basis = {variable: Basis(mesh, e, intorder=3)
          for variable, e in element.items()}
@@ -61,7 +61,7 @@ basis = {variable: Basis(mesh, e, intorder=3)
 
 @LinearForm
 def body_force(v, w):
-    return w.x[0] * v.value[1]
+    return w.x[0] * v[1]
 
 
 A = asm(vector_laplace, basis['u'])

--- a/docs/examples/ex20.py
+++ b/docs/examples/ex20.py
@@ -54,7 +54,7 @@ psi = solve(*condense(stokes, rotf, D=ib.get_dofs()))
 
 velocity = asm(
     LinearForm(curluv).partial(ib.interpolate(psi)),
-    ib.with_element(ElementVectorH1(ElementTriP1())),
+    ib.with_element(ElementVector(ElementTriP1())),
 )
 
 if __name__ == "__main__":

--- a/docs/examples/ex21.py
+++ b/docs/examples/ex21.py
@@ -69,7 +69,7 @@ from pathlib import Path
 
 m = MeshTet.load(Path(__file__).parent / 'meshes' / 'beams.msh')
 e1 = ElementTetP2()
-e = ElementVectorH1(e1)
+e = ElementVector(e1)
 
 ib = Basis(m, e)
 

--- a/docs/examples/ex27.py
+++ b/docs/examples/ex27.py
@@ -100,7 +100,7 @@ def acceleration_jacobian(u, v, w):
 
 class BackwardFacingStep:
 
-    element = {'u': ElementVectorH1(ElementTriP2()),
+    element = {'u': ElementVector(ElementTriP2()),
                'p': ElementTriP1()}
 
     def __init__(self,

--- a/docs/examples/ex30.py
+++ b/docs/examples/ex30.py
@@ -63,7 +63,7 @@ from scipy.sparse.linalg import LinearOperator, minres
 
 mesh = MeshQuad.init_tensor(*(np.linspace(-.5, .5, 2**6),)*2)
 
-element = {'u': ElementVectorH1(ElementQuad2()),
+element = {'u': ElementVector(ElementQuad2()),
            'p': ElementQuad1()}
 basis = {variable: Basis(mesh, e, intorder=3)
          for variable, e in element.items()}
@@ -71,7 +71,7 @@ basis = {variable: Basis(mesh, e, intorder=3)
 
 @LinearForm
 def body_force(v, w):
-    return w.x[0] * v.value[1]
+    return w.x[0] * v[1]
 
 
 A = asm(vector_laplace, basis['u'])

--- a/docs/examples/ex32.py
+++ b/docs/examples/ex32.py
@@ -107,7 +107,7 @@ class Sphere(NamedTuple):
 ball = Sphere()
 mesh = ball.mesh()
 
-element = {'u': ElementVectorH1(ElementTetP2()),
+element = {'u': ElementVector(ElementTetP2()),
            'p': ElementTetP1()}
 basis = {variable: Basis(mesh, e, intorder=3)
          for variable, e in element.items()}
@@ -115,7 +115,7 @@ basis = {variable: Basis(mesh, e, intorder=3)
 
 @LinearForm
 def body_force(v, w):
-    return w.x[0] * v.value[1]
+    return w.x[0] * v[1]
 
 
 A = asm(vector_laplace, basis['u'])

--- a/docs/examples/ex36.py
+++ b/docs/examples/ex36.py
@@ -95,7 +95,7 @@ def F1(w):
 
 def F2(w):
     u = w["disp"]
-    p = w["press"].value
+    p = w["press"]
     F = grad(u) + identity(u)
     J = det(F)
     Js = .5 * (lmbda + p + 2. * np.sqrt(lmbda * mu + .25 * (lmbda + p) ** 2)) / lmbda
@@ -127,7 +127,7 @@ def A12(w):
 
 def A22(w):
     u = w["disp"]
-    p = w["press"].value
+    p = w["press"]
     Js = .5 * (lmbda + p + 2. * np.sqrt(lmbda * mu + .25 * (lmbda + p) ** 2)) / lmbda
     dJsdp = ((.25 * lmbda + .25 * p + .5 * np.sqrt(lmbda * mu + .25 * (lmbda + p) ** 2))
              / (lmbda * np.sqrt(lmbda * mu + .25 * (lmbda + p) ** 2)))
@@ -156,7 +156,7 @@ mesh = (
         }
     )
 )
-uelem = ElementVectorH1(ElementTetP2())
+uelem = ElementVector(ElementTetP2())
 pelem = ElementTetP1()
 elems = {
     "u": uelem,

--- a/docs/gettingstarted.rst
+++ b/docs/gettingstarted.rst
@@ -113,7 +113,7 @@ Here we choose the piecewise-linear basis:
    <skfem CellBasis(MeshTri1, ElementTriP1) object>
      Number of elements: 128
      Number of DOFs: 81
-     Size: 27648 B
+     Size: 9216 B
 
 Step 5: Assemble the linear system
 ==================================

--- a/skfem/assembly/basis/abstract_basis.py
+++ b/skfem/assembly/basis/abstract_basis.py
@@ -426,10 +426,10 @@ class AbstractBasis:
         from skfem.helpers import inner
 
         if isinstance(interp, float):
-            interp = interp + self.global_coordinates().value[0] * 0.
+            interp = interp + self.global_coordinates()[0] * 0.
 
         if callable(interp):
-            interp = interp(self.global_coordinates().value)
+            interp = interp(self.global_coordinates())
 
         return (
             BilinearForm(lambda u, v, _: inner(u, v)).assemble(self),

--- a/skfem/assembly/basis/abstract_basis.py
+++ b/skfem/assembly/basis/abstract_basis.py
@@ -343,7 +343,7 @@ class AbstractBasis:
                     if self.basis[i][c].is_zero():
                         continue
                     out += np.einsum('...,...j->...j', values,
-                                     self.basis[i][c].astuple[n])
+                                     self.basis[i][c].get(n))
                 return out
 
             # interpolate DiscreteField

--- a/skfem/assembly/basis/abstract_basis.py
+++ b/skfem/assembly/basis/abstract_basis.py
@@ -332,6 +332,7 @@ class AbstractBasis:
             if ref.is_zero():
                 dfs.append(ref)
                 continue
+            ref = ref.astuple
             fs = []
 
             def linear_combination(n, refn):
@@ -342,7 +343,7 @@ class AbstractBasis:
                     if self.basis[i][c].is_zero():
                         continue
                     out += np.einsum('...,...j->...j', values,
-                                     self.basis[i][c][n])
+                                     self.basis[i][c].astuple[n])
                 return out
 
             # interpolate DiscreteField

--- a/skfem/assembly/basis/cell_basis.py
+++ b/skfem/assembly/basis/cell_basis.py
@@ -120,7 +120,13 @@ class CellBasis(AbstractBasis):
 
         # interpolate some previous discrete function at the vertices
         # of the refined mesh
-        w = 0. * x[0]
+        test = self.elem.gbasis(self.mapping, X, 0)[0]
+        if len(test.shape) == 3:
+            w = 0. * x
+        elif len(test.shape) == 2:
+            w = 0. * x[0]
+        else:
+            raise NotImplementedError
         for j in range(self.Nbfun):
             basis = self.elem.gbasis(self.mapping, X, j)
             w += y[self.element_dofs[j]][:, None] * basis[0]

--- a/skfem/assembly/basis/cell_basis.py
+++ b/skfem/assembly/basis/cell_basis.py
@@ -161,7 +161,7 @@ class CellBasis(AbstractBasis):
         pts = self.mapping.invF(x[:, :, np.newaxis], tind=cells)
         phis = np.array(
             [
-                self.elem.gbasis(self.mapping, pts, k, tind=cells)[0][0]
+                self.elem.gbasis(self.mapping, pts, k, tind=cells)[0].value
                 for k in range(self.Nbfun)
             ]
         ).flatten()

--- a/skfem/assembly/basis/cell_basis.py
+++ b/skfem/assembly/basis/cell_basis.py
@@ -167,7 +167,7 @@ class CellBasis(AbstractBasis):
         pts = self.mapping.invF(x[:, :, np.newaxis], tind=cells)
         phis = np.array(
             [
-                self.elem.gbasis(self.mapping, pts, k, tind=cells)[0].value
+                self.elem.gbasis(self.mapping, pts, k, tind=cells)[0]
                 for k in range(self.Nbfun)
             ]
         ).flatten()

--- a/skfem/assembly/form/form.py
+++ b/skfem/assembly/form/form.py
@@ -19,15 +19,7 @@ class FormExtraParams(dict):
     """Passed to forms as 'w'."""
 
     def __getattr__(self, attr):
-        if attr[:4] == 'sign':
-            # for backwards compatibility
-            ix = int(attr[4]) - 1 if len(attr) == 5 else 0
-            if hasattr(self, 'idx') and ix < len(self['idx']):
-                return (-1.) ** self['idx'][ix]
-            return 1.
         if attr in self:
-            if hasattr(self[attr], 'value'):
-                return self[attr].value
             return self[attr]
         raise ValueError
 

--- a/skfem/assembly/form/form.py
+++ b/skfem/assembly/form/form.py
@@ -21,7 +21,7 @@ class FormExtraParams(dict):
     def __getattr__(self, attr):
         if attr in self:
             return self[attr]
-        raise ValueError("Attribute '{}' not found in 'w'.".format(attr))
+        raise AttributeError("Attribute '{}' not found in 'w'.".format(attr))
 
 
 class Form:

--- a/skfem/assembly/form/form.py
+++ b/skfem/assembly/form/form.py
@@ -21,7 +21,7 @@ class FormExtraParams(dict):
     def __getattr__(self, attr):
         if attr in self:
             return self[attr]
-        raise ValueError
+        raise ValueError("Attribute '{}' not found in 'w'.".format(attr))
 
 
 class Form:

--- a/skfem/element/discrete_field.py
+++ b/skfem/element/discrete_field.py
@@ -79,7 +79,8 @@ class DiscreteField(ndarray):
         rep = ""
         rep += "<skfem DiscreteField object>"
         if not self.is_zero():
-            rep += "\n  Quadrature points per element: {}".format(self.shape[-1])
+            rep += ("\n  Quadrature points per element: {}"
+                    .format(self.shape[-1]))
             rep += "\n  Number of elements: {}".format(self.shape[-2])
             rep += "\n  Order: {}".format(len(self.shape) - 2)
         rep += "\n  Attributes: {}".format(

--- a/skfem/element/discrete_field.py
+++ b/skfem/element/discrete_field.py
@@ -4,86 +4,73 @@ import numpy as np
 from numpy import ndarray
 
 
-class DiscreteField(NamedTuple):
-    """A function defined at the global quadrature points.
+class DiscreteField(ndarray):
 
-    Created using :meth:`~skfem.element.Element.gbasis` or
-    :meth:`~skfem.assembly.CellBasis.interpolate`.
+    def __new__(cls,
+                value=np.array([0]),
+                grad=None,
+                div=None,
+                curl=None,
+                hess=None,
+                grad3=None,
+                grad4=None,
+                grad5=None,
+                grad6=None):
+        obj = np.asarray(value).view(cls)
+        obj.grad = grad
+        obj.div = div
+        obj.curl = curl
+        obj.hess = hess
+        obj.grad3 = grad3
+        obj.grad4 = grad4
+        obj.grad5 = grad5
+        obj.grad6 = grad6
+        return obj
 
-    """
+    def __array_finalize__(self, obj):
+        if obj is None: return
+        self.grad = getattr(obj, 'grad', None)
+        self.div = getattr(obj, 'div', None)
+        self.curl = getattr(obj, 'curl', None)
+        self.hess = getattr(obj, 'hess', None)
+        self.grad3 = getattr(obj, 'grad3', None)
+        self.grad4 = getattr(obj, 'grad4', None)
+        self.grad5 = getattr(obj, 'grad5', None)
+        self.grad6 = getattr(obj, 'grad6', None)
 
-    value: ndarray = np.array([0])  # zero field
-    grad: Optional[ndarray] = None
-    div: Optional[ndarray] = None
-    curl: Optional[ndarray] = None
-    hess: Optional[ndarray] = None
-    grad3: Optional[ndarray] = None
-    grad4: Optional[ndarray] = None
-    grad5: Optional[ndarray] = None
-    grad6: Optional[ndarray] = None
+    @property
+    def astuple(self):
+        return (
+            np.array(self),
+            self.grad,
+            self.div,
+            self.curl,
+            self.hess,
+            self.grad3,
+            self.grad4,
+            self.grad5,
+            self.grad6,
+        )
 
-    def __array__(self):
-        return self.value
-
-    def __add__(self, other):
-        if isinstance(other, DiscreteField):
-            return self.value + other.value
-        return self.value + other
-
-    def __sub__(self, other):
-        if isinstance(other, DiscreteField):
-            return self.value - other.value
-        return self.value - other
-
-    def __mul__(self, other):
-        if isinstance(other, DiscreteField):
-            return self.value * other.value
-        return self.value * other
-
-    def __truediv__(self, other):
-        if isinstance(other, DiscreteField):
-            return self.value / other.value
-        return self.value / other
-
-    def __pow__(self, other):
-        if isinstance(other, DiscreteField):
-            return self.value ** other.value
-        return self.value ** other
-
-    def __neg__(self):
-        return -self.value
-
-    def __radd__(self, other):
-        return self.__add__(other)
-
-    def __rsub__(self, other):
-        return other - self.value
-
-    def __rmul__(self, other):
-        return self.__mul__(other)
-
-    def __rtruediv__(self, other):
-        return other / self.value
-
-    def __rpow__(self, other):
-        return other ** self.value
-
-    def _split(self):
-        """Split all components based on their first dimension."""
-        return [DiscreteField(*[f[i] for f in self if f is not None])
-                for i in range(self.value.shape[0])]
+    @property
+    def value(self):
+        return self
 
     def is_zero(self):
-        if self.value.shape == (1,):
-            return True
-        return False
+        return self.shape == (1,)
 
-    def zeros_like(self) -> 'DiscreteField':
-        """Return zero :class:`~skfem.element.DiscreteField` with same size."""
+    def __reduce__(self):
+        pickled_state = super(DiscreteField, self).__reduce__()
+        new_state = pickled_state[2] + self.astuple[1:]
+        return (pickled_state[0], pickled_state[1], new_state)
 
-        def zero_or_none(x):
-            if x is None:
-                return None
-            return np.zeros_like(x)
-
-        return DiscreteField(*[zero_or_none(field) for field in self])
+    def __setstate__(self, state):
+        self.grad = state[-8]
+        self.div = state[-7]
+        self.curl = state[-6]
+        self.hess = state[-5]
+        self.grad3 = state[-4]
+        self.grad4 = state[-3]
+        self.grad5 = state[-2]
+        self.grad6 = state[-1]
+        super(DiscreteField, self).__setstate__(state[0:-8])

--- a/skfem/element/discrete_field.py
+++ b/skfem/element/discrete_field.py
@@ -52,28 +52,31 @@ class DiscreteField(ndarray):
         # attributes are invalidated after ufuncs
         return np.array(out_arr)
 
+    def get(self, n):
+        if n == 0:
+            return np.array(self)
+        return getattr(self, self._extra_attrs[n - 1])
+
     @property
     def astuple(self):
         return tuple(self.get(i) for i in range(len(self._extra_attrs) + 1))
 
     @property
     def value(self):
+        # increase backwards-compatibility
         return self
-
-    def get(self, n):
-        if n == 0:
-            return np.array(self)
-        return getattr(self, self._extra_attrs[n - 1])
 
     def is_zero(self):
         return self.shape == (1,)
 
     def __reduce__(self):
+        # for pickling
         pickled_state = super(DiscreteField, self).__reduce__()
         new_state = pickled_state[2] + self.astuple[1:]
         return (pickled_state[0], pickled_state[1], new_state)
 
     def __setstate__(self, state):
+        # for pickling
         nattrs = len(self._extra_attrs)
         for i in range(nattrs):
             setattr(self, self._extra_attrs[i], state[-nattrs + i])

--- a/skfem/element/discrete_field.py
+++ b/skfem/element/discrete_field.py
@@ -1,5 +1,3 @@
-from typing import NamedTuple, Optional
-
 import numpy as np
 from numpy import ndarray
 
@@ -28,7 +26,8 @@ class DiscreteField(ndarray):
         return obj
 
     def __array_finalize__(self, obj):
-        if obj is None: return
+        if obj is None:
+            return
         self.grad = getattr(obj, 'grad', None)
         self.div = getattr(obj, 'div', None)
         self.curl = getattr(obj, 'curl', None)

--- a/skfem/element/discrete_field.py
+++ b/skfem/element/discrete_field.py
@@ -48,6 +48,10 @@ class DiscreteField(ndarray):
         self.grad5 = getattr(obj, 'grad5', None)
         self.grad6 = getattr(obj, 'grad6', None)
 
+    def __array_wrap__(self, out_arr, context=None):
+        # attributes are invalidated after ufuncs
+        return np.array(out_arr)
+
     @property
     def astuple(self):
         return tuple(self.get(i) for i in range(len(self._extra_attrs) + 1))

--- a/skfem/element/discrete_field.py
+++ b/skfem/element/discrete_field.py
@@ -83,11 +83,11 @@ class DiscreteField(ndarray):
                     .format(self.shape[-1]))
             rep += "\n  Number of elements: {}".format(self.shape[-2])
             rep += "\n  Order: {}".format(len(self.shape) - 2)
-        rep += "\n  Attributes: {}".format(
-            ', '.join([attr
-                       for attr in self._extra_attrs
-                       if getattr(self, attr) is not None])
-        )
+            rep += "\n  Attributes: {}".format(
+                ', '.join([attr
+                           for attr in self._extra_attrs
+                           if getattr(self, attr) is not None])
+            )
         return rep
 
     def __reduce__(self):

--- a/skfem/element/discrete_field.py
+++ b/skfem/element/discrete_field.py
@@ -39,13 +39,18 @@ class DiscreteField(ndarray):
     def __array_finalize__(self, obj):
         if obj is None:
             return
-        for k in self._extra_attrs:
-            setattr(self, k, getattr(obj, k, None))
+        self.grad = getattr(obj, 'grad', None)
+        self.div = getattr(obj, 'div', None)
+        self.curl = getattr(obj, 'curl', None)
+        self.hess = getattr(obj, 'hess', None)
+        self.grad3 = getattr(obj, 'grad3', None)
+        self.grad4 = getattr(obj, 'grad4', None)
+        self.grad5 = getattr(obj, 'grad5', None)
+        self.grad6 = getattr(obj, 'grad6', None)
 
     @property
     def astuple(self):
-        return (np.array(self),) + tuple(getattr(self, k)
-                                         for k in self._extra_attrs)
+        return tuple(self.get(i) for i in range(len(self._extra_attrs) + 1))
 
     @property
     def value(self):
@@ -53,7 +58,7 @@ class DiscreteField(ndarray):
 
     def get(self, n):
         if n == 0:
-            return self
+            return np.array(self)
         return getattr(self, self._extra_attrs[n - 1])
 
     def is_zero(self):

--- a/skfem/element/discrete_field.py
+++ b/skfem/element/discrete_field.py
@@ -51,6 +51,11 @@ class DiscreteField(ndarray):
     def value(self):
         return self
 
+    def get(self, n):
+        if n == 0:
+            return self
+        return getattr(self, self._extra_attrs[n - 1])
+
     def is_zero(self):
         return self.shape == (1,)
 

--- a/skfem/element/discrete_field.py
+++ b/skfem/element/discrete_field.py
@@ -1,3 +1,5 @@
+from warnings import warn
+
 import numpy as np
 from numpy import ndarray
 
@@ -70,6 +72,8 @@ class DiscreteField(ndarray):
     @property
     def value(self):
         # for backwards-compatibility
+        warn("Writing 'u.value' is unnecessary "
+             "and can be replaced by 'u'.", DeprecationWarning)
         return np.array(self)
 
     def is_zero(self):
@@ -83,11 +87,11 @@ class DiscreteField(ndarray):
                     .format(self.shape[-1]))
             rep += "\n  Number of elements: {}".format(self.shape[-2])
             rep += "\n  Order: {}".format(len(self.shape) - 2)
-            rep += "\n  Attributes: {}".format(
-                ', '.join([attr
-                           for attr in self._extra_attrs
-                           if getattr(self, attr) is not None])
-            )
+            attrs = ', '.join([attr
+                               for attr in self._extra_attrs
+                               if getattr(self, attr) is not None])
+            if len(attrs) > 0:
+                rep += "\n  Attributes: {}".format(attrs)
         return rep
 
     def __reduce__(self):

--- a/skfem/element/element_vector.py
+++ b/skfem/element/element_vector.py
@@ -38,7 +38,7 @@ class ElementVector(Element):
         ind = int(np.floor(float(i) / float(self.dim)))
         n = i - self.dim * ind
         fields = []
-        for field in self.elem.gbasis(mapping, X, ind, tind)[0]:
+        for field in self.elem.gbasis(mapping, X, ind, tind)[0].astuple:
             if field is None:
                 fields.append(None)
             else:

--- a/skfem/helpers.py
+++ b/skfem/helpers.py
@@ -100,14 +100,12 @@ def inner(u: FieldOrArray, v: FieldOrArray):
         return u
     if isinstance(v, DiscreteField) and v.is_zero():
         return v
-    U = u.value if isinstance(u, DiscreteField) else u
-    V = v.value if isinstance(v, DiscreteField) else v
-    if len(U.shape) == 2:
-        return U * V
-    elif len(U.shape) == 3:
-        return dot(U, V)
-    elif len(U.shape) == 4:
-        return ddot(U, V)
+    if len(u.shape) == 2:
+        return u * v
+    elif len(u.shape) == 3:
+        return dot(u, v)
+    elif len(u.shape) == 4:
+        return ddot(u, v)
     raise NotImplementedError
 
 
@@ -180,21 +178,13 @@ def eye(w, n):
 
 def identity(w, N=None):
     """Create identity matrix."""
-    if isinstance(w, DiscreteField):
-        proto = w.value
-    elif isinstance(w, ndarray):
-        proto = w
-    else:
-        raise NotImplementedError
-
     if N is None:
-        if len(proto.shape) > 2:
-            N = proto.shape[-3]
+        if len(w.shape) > 2:
+            N = w.shape[-3]
         else:
             raise ValueError("Cannot deduce the size of the identity matrix. "
                              "Give an explicit keyword argument N.")
-
-    return eye(np.ones(proto.shape[-2:]), N)
+    return eye(np.ones(w.shape[-2:]), N)
 
 
 def det(A):

--- a/skfem/utils.py
+++ b/skfem/utils.py
@@ -616,11 +616,11 @@ def projection(fun,
     def mass(u, v, w):
         from skfem.helpers import dot, ddot
         p = 0
-        if len(u.value.shape) == 2:
+        if len(u.shape) == 2:
             p = u * v
-        elif len(u.value.shape) == 3:
+        elif len(u.shape) == 3:
             p = dot(u, v)
-        elif len(u.value.shape) == 4:
+        elif len(u.shape) == 4:
             p = ddot(u, v)
         return p
 

--- a/skfem/visuals/matplotlib.py
+++ b/skfem/visuals/matplotlib.py
@@ -223,12 +223,15 @@ def plot_meshtri(m: MeshTri1, z: ndarray, **kwargs) -> Axes:
     else:
         cmap = plt.cm.jet
 
-    im = ax.tripcolor(m.p[0], m.p[1], m.t.T, z, cmap=cmap,
-                      **{k: v for k, v in kwargs.items()
-                         if k in ['shading',
-                                  'edgecolors',
-                                  'vmin',
-                                  'vmax']})
+    if len(z) == 2 * len(m.p[0]):
+        im = ax.quiver(m.p[0], m.p[1], *z.reshape(2, -1))
+    else:
+        im = ax.tripcolor(m.p[0], m.p[1], m.t.T, z, cmap=cmap,
+                          **{k: v for k, v in kwargs.items()
+                             if k in ['shading',
+                                      'edgecolors',
+                                      'vmin',
+                                      'vmax']})
 
     if "levels" in kwargs:
         ax.tricontour(m.p[0], m.p[1], m.t.T, z,

--- a/tests/test_convergence.py
+++ b/tests/test_convergence.py
@@ -97,7 +97,7 @@ class ConvergenceQ1(unittest.TestCase):
         return ib.get_dofs().all('u')
 
     def compute_error(self, m, basis, U):
-        uh, duh, *_ = basis.interpolate(U)
+        uh, duh, *_ = basis.interpolate(U).astuple
         dx = basis.dx
         x = basis.global_coordinates()
 
@@ -464,10 +464,7 @@ class FacetConvergenceTetP2(unittest.TestCase):
 
     def runTest(self):
 
-        @BilinearForm
-        def dudv(u, v, w):
-            du, dv = u[1], v[1]
-            return sum(du * dv)
+        dudv = laplace
 
         @BilinearForm
         def uv(u, v, w):
@@ -528,7 +525,7 @@ class FacetConvergenceTetP2(unittest.TestCase):
         self.assertLess(L2err[-1], 0.005)
 
     def compute_error(self, m, basis, U):
-        uh, duh, *_ = basis.interpolate(U)
+        uh, duh, *_ = basis.interpolate(U).astuple
         dx = basis.dx
         x = basis.global_coordinates().value
 

--- a/tests/test_convergence_hdiv.py
+++ b/tests/test_convergence_hdiv.py
@@ -85,7 +85,7 @@ class ConvergenceRaviartThomas(unittest.TestCase):
         self.assertLess(L2s[-1], self.L2bound)
 
     def compute_L2(self, m, basis, U):
-        uh, *_ = basis.interpolate(U)
+        uh, *_ = basis.interpolate(U).astuple
         dx = basis.dx
         x = basis.global_coordinates()
 
@@ -102,7 +102,7 @@ class ConvergenceRaviartThomas(unittest.TestCase):
         return np.sqrt(np.sum(np.sum((uh - u(x.value)) ** 2 * dx, axis=1)))
 
     def compute_Hdiv(self, m, basis, U):
-        uh, duh, *_ = basis.interpolate(U)
+        uh, duh, *_ = basis.interpolate(U).astuple
         dx = basis.dx
         x = basis.global_coordinates()
 

--- a/tests/test_p_convergence.py
+++ b/tests/test_p_convergence.py
@@ -47,7 +47,7 @@ class ConvergenceLinePp(unittest.TestCase):
         self.assertLess(L2s[-1], 1e-13)
 
     def compute_error(self, m, basis, U):
-        uh, duh, *_ = basis.interpolate(U)
+        uh, duh, *_ = basis.interpolate(U).astuple
         dx = basis.dx
         x = basis.global_coordinates()
 
@@ -106,7 +106,7 @@ class ConvergenceQuadP(unittest.TestCase):
         self.assertLess(L2s[-1], 1e-11)
 
     def compute_error(self, m, basis, U):
-        uh, duh, *_ = basis.interpolate(U)
+        uh, duh, *_ = basis.interpolate(U).astuple
         dx = basis.dx
         x = basis.global_coordinates()
 

--- a/tests/test_visuals.py
+++ b/tests/test_visuals.py
@@ -1,5 +1,7 @@
-import unittest
+from unittest import TestCase
 import pytest
+
+import matplotlib.pyplot as plt
 
 from skfem.assembly import CellBasis
 from skfem.mesh import (MeshTri, MeshQuad, MeshTet, MeshLine1, MeshTri2,
@@ -9,12 +11,16 @@ from skfem.visuals.svg import draw as drawsvg
 from skfem.visuals.svg import plot as plotsvg
 
 
-class CallDraw(unittest.TestCase):
+class CallDraw(TestCase):
     mesh_type = MeshTri
 
     def runTest(self):
         m = self.mesh_type()
-        draw(m)
+        draw(m,
+             aspect=1.1,
+             facet_numbering=True,
+             node_numbering=True,
+             element_numbering=True)
 
 
 class CallDrawQuad(CallDraw):
@@ -25,7 +31,7 @@ class CallDrawTet(CallDraw):
     mesh_type = MeshTet
 
 
-class CallPlot(unittest.TestCase):
+class CallPlot(TestCase):
     mesh_type = MeshTri
 
     def runTest(self):
@@ -41,12 +47,36 @@ class CallPlotLine(CallPlot):
     mesh_type = MeshLine1
 
 
-class CallPlot3(unittest.TestCase):
+class CallPlot3(TestCase):
     mesh_type = MeshTri
 
     def runTest(self):
         m = self.mesh_type()
         plot3(m, m.p[0])
+
+
+class CallPlotBasis(TestCase):
+    mesh_type = MeshTri
+
+    def runTest(self):
+        m = self.mesh_type()
+        basis = CellBasis(m, self.mesh_type.elem())
+        y = basis.project(lambda x: x[0])
+        plot(basis,
+             y,
+             nrefs=1,
+             figsize=(4, 4),
+             aspect=1.1,
+             cmap=plt.get_cmap('viridis'),
+             shading='gouraud',
+             vmin=0,
+             vmax=1,
+             levels=3,
+             colorbar=True)
+
+
+class CallPlotBasisQuad(CallPlotBasis):
+    mesh_type = MeshQuad
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR turns `DiscreteField` into a subclass of `ndarray` instead of `NamedTuple`.
The benefit is that now `DiscreteField` objects automatically behave just like `DiscreteField.value` previously did and there is hopefully no more need to write `u.value` inside the forms.

As a side effect you can do stuff like this:
```python
In [1]: from skfem import *                                                                              
In [2]: m = MeshTri()                                                                                    
In [3]: basis = Basis(m, ElementTriP1())                                                                 
In [4]: fun = basis.project(lambda x: x[0]) 
In [7]: @LinearForm 
   ...: def linf(v, w): 
   ...:     return w.fun.grad[0] * v 
   ...:                                                                                                  
In [8]: linf.assemble(basis, fun=fun)                                                                      
Out[8]: array([0.16666667, 0.33333333, 0.33333333, 0.16666667])
```
Traditionally such form would fail because `w.fun` would be just `ndarray` and not `DiscreteField`.

Fixes #847.