### PR TITLE
Add SubdomainFacetBasis v2

### DIFF
--- a/skfem/assembly/basis/abstract_basis.py
+++ b/skfem/assembly/basis/abstract_basis.py
@@ -240,48 +240,48 @@ class AbstractBasis:
             raise ValueError
 
         if elements is not None:
-            elements = self._normalize_elements(elements)
+            elements = self._normalize_elements(self.mesh, elements)
             return self.dofs.get_element_dofs(elements, skip_dofnames=skip)
 
-        facets = self._normalize_facets(facets)
+        facets = self._normalize_facets(self.mesh, facets)
         return self.dofs.get_facet_dofs(facets, skip_dofnames=skip)
 
-    def _normalize_facets(self, facets):
+    def _normalize_facets(self, mesh, facets):
         if isinstance(facets, ndarray):
             return facets
         if facets is None:
-            return self.mesh.boundary_facets()
+            return mesh.boundary_facets()
         elif isinstance(facets, (tuple, list, set)):
             return np.unique(
                 np.concatenate(
-                    [self._normalize_facets(f) for f in facets]
+                    [self._normalize_facets(mesh, f) for f in facets]
                 )
             )
         elif callable(facets):
-            return self.mesh.facets_satisfying(facets)
+            return mesh.facets_satisfying(facets)
         elif isinstance(facets, str):
-            if ((self.mesh.boundaries is not None
-                 and facets in self.mesh.boundaries)):
-                return self.mesh.boundaries[facets]
+            if ((mesh.boundaries is not None
+                 and facets in mesh.boundaries)):
+                return mesh.boundaries[facets]
             else:
                 raise ValueError("Boundary '{}' not found.".format(facets))
         raise NotImplementedError
 
-    def _normalize_elements(self, elements):
+    def _normalize_elements(self, mesh, elements):
         if isinstance(elements, ndarray):
             return elements
         if callable(elements):
-            return self.mesh.elements_satisfying(elements)
+            return mesh.elements_satisfying(elements)
         elif isinstance(elements, (tuple, list, set)):
             return np.unique(
                 np.concatenate(
-                    [self._normalize_elements(e) for e in elements]
+                    [self._normalize_elements(mesh, e) for e in elements]
                 )
             )
         elif isinstance(elements, str):
-            if ((self.mesh.subdomains is not None
-                 and elements in self.mesh.subdomains)):
-                return self.mesh.subdomains[elements]
+            if ((mesh.subdomains is not None
+                 and elements in mesh.subdomains)):
+                return mesh.subdomains[elements]
             else:
                 raise ValueError("Subdomain '{}' not found.".format(elements))
         raise NotImplementedError

--- a/skfem/assembly/basis/boundary_facet_basis.py
+++ b/skfem/assembly/basis/boundary_facet_basis.py
@@ -69,7 +69,7 @@ class BoundaryFacetBasis(AbstractBasis):
         if facets is None:
             self.find = np.nonzero(self.mesh.f2t[1] == -1)[0]
         else:
-            self.find = self._normalize_facets(facets)
+            self.find = self._normalize_facets(mesh, facets)
 
         if len(self.find) == 0:
             logger.warning("Initializing {} with zero facets.".format(typestr))

--- a/skfem/assembly/basis/boundary_facet_basis.py
+++ b/skfem/assembly/basis/boundary_facet_basis.py
@@ -28,7 +28,8 @@ class BoundaryFacetBasis(AbstractBasis):
                  quadrature: Optional[Tuple[ndarray, ndarray]] = None,
                  facets: Optional[ndarray] = None,
                  dofs: Optional[Dofs] = None,
-                 _tind: Optional[ndarray] = None):
+                 _tind: Optional[ndarray] = None,
+                 _tind_normals: Optional[ndarray] = None):
         """Precomputed global basis on boundary facets.
 
         Parameters
@@ -83,13 +84,17 @@ class BoundaryFacetBasis(AbstractBasis):
         # global facet to refdom facet
         Y = self.mapping.invF(x, tind=self.tind)
 
-        # construct normal vectors from side=0 always
-        Y0 = self.mapping.invF(x, tind=self.mesh.f2t[0, self.find])
+        if _tind_normals is None:
+            # construct normal vectors from side=0 by default
+            _tind_normals = self.mesh.f2t[0, self.find]
+
         self.normals = DiscreteField(
-            value=self.mapping.normals(Y0,
-                                       self.mesh.f2t[0, self.find],
-                                       self.find,
-                                       self.mesh.t2f)
+            value=self.mapping.normals(
+                self.mapping.invF(x, tind=_tind_normals),
+                _tind_normals,
+                self.find,
+                self.mesh.t2f,
+            ),
         )
 
         self.nelems = len(self.find)

--- a/skfem/assembly/basis/cell_basis.py
+++ b/skfem/assembly/basis/cell_basis.py
@@ -85,7 +85,7 @@ class CellBasis(AbstractBasis):
             self.tind = None
         else:
             self.nelems = len(elements)
-            self.tind = self._normalize_elements(elements)
+            self.tind = self._normalize_elements(mesh, elements)
 
         self.dx = (np.abs(self.mapping.detDF(self.X, tind=elements))
                    * np.tile(self.W, (self.nelems, 1)))

--- a/skfem/assembly/basis/interior_facet_basis.py
+++ b/skfem/assembly/basis/interior_facet_basis.py
@@ -34,7 +34,7 @@ class InteriorFacetBasis(BoundaryFacetBasis):
         if facets is None:
             facets = np.nonzero(mesh.f2t[1] != -1)[0]
 
-        facets = self._normalize_facets(facets)
+        facets = self._normalize_facets(mesh, facets)
         tind = mesh.f2t[side, facets]
 
         super(InteriorFacetBasis, self).__init__(mesh,

--- a/skfem/assembly/basis/mortar_facet_basis.py
+++ b/skfem/assembly/basis/mortar_facet_basis.py
@@ -31,7 +31,7 @@ class MortarFacetBasis(BoundaryFacetBasis):
             mapping.side = side
             facets = mapping.helper_to_orig[side]
 
-        facets = self._normalize_facets(facets)
+        facets = self._normalize_facets(mesh, facets)
 
         super(MortarFacetBasis, self).__init__(mesh,
                                                elem,

--- a/skfem/assembly/basis/subdomain_facet_basis.py
+++ b/skfem/assembly/basis/subdomain_facet_basis.py
@@ -13,19 +13,21 @@ from ..dofs import Dofs
 class SubdomainFacetBasis(BoundaryFacetBasis):
 
     def __init__(self,
-                 mesh,
-                 elem,
-                 mapping=None,
-                 intorder=None,
-                 elements=None,
-                 quadrature=None,
+                 mesh: Mesh,
+                 elem: Element,
+                 mapping: Optional[Mapping] = None,
+                 intorder: Optional[int] = None,
+                 elements: Optional[ndarray] = None,
+                 quadrature: Optional[Tuple[ndarray, ndarray]] = None,
                  side: int = 0,
-                 dofs=None):
+                 dofs: Optional[Dofs] = None):
 
         assert elements is not None
         self.mesh = mesh  # required by _normalize_elements
         elements = self._normalize_elements(elements)
-        all_facets, counts = np.unique(mesh.t2f[:, elements], return_counts=True)
+        assert isinstance(elements, ndarray)
+        all_facets, counts = np.unique(mesh.t2f[:, elements],
+                                       return_counts=True)
         facets = all_facets[counts == 1]
         tind = mesh.f2t[:, facets].flatten('F')
         ix = np.in1d(tind, elements)

--- a/skfem/assembly/basis/subdomain_facet_basis.py
+++ b/skfem/assembly/basis/subdomain_facet_basis.py
@@ -23,8 +23,7 @@ class SubdomainFacetBasis(BoundaryFacetBasis):
                  dofs: Optional[Dofs] = None):
 
         assert elements is not None
-        self.mesh = mesh  # required by _normalize_elements
-        elements = self._normalize_elements(elements)
+        elements = self._normalize_elements(mesh, elements)
         assert isinstance(elements, ndarray)
         all_facets, counts = np.unique(mesh.t2f[:, elements],
                                        return_counts=True)
@@ -39,7 +38,7 @@ class SubdomainFacetBasis(BoundaryFacetBasis):
             intorder=intorder,
             quadrature=quadrature,
             facets=facets,
+            dofs=dofs,
             _tind=_tind,
             _tind_normals=_tind,
-            dofs=dofs,
         )

--- a/skfem/assembly/basis/subdomain_facet_basis.py
+++ b/skfem/assembly/basis/subdomain_facet_basis.py
@@ -1,0 +1,43 @@
+from typing import Optional, Tuple
+
+import numpy as np
+from numpy import ndarray
+from skfem.element import Element
+from skfem.mapping import Mapping
+from skfem.mesh import Mesh
+
+from .boundary_facet_basis import BoundaryFacetBasis
+from ..dofs import Dofs
+
+
+class SubdomainFacetBasis(BoundaryFacetBasis):
+
+    def __init__(self,
+                 mesh,
+                 elem,
+                 mapping=None,
+                 intorder=None,
+                 elements=None,
+                 quadrature=None,
+                 side: int = 0,
+                 dofs=None):
+
+        assert elements is not None
+        self.mesh = mesh  # required by _normalize_elements
+        elements = self._normalize_elements(elements)
+        all_facets, counts = np.unique(mesh.t2f[:, elements], return_counts=True)
+        facets = all_facets[counts == 1]
+        tind = mesh.f2t[:, facets].flatten('F')
+        ix = np.in1d(tind, elements)
+        _tind = tind[~ix] if side == 1 else tind[ix]
+        super().__init__(
+            mesh,
+            elem,
+            mapping=mapping,
+            intorder=intorder,
+            quadrature=quadrature,
+            facets=facets,
+            _tind=_tind,
+            _tind_normals=_tind,
+            dofs=dofs,
+        )


### PR DESCRIPTION
My test snippet:
```python
from skfem import *
from skfem.assembly.basis.subdomain_facet_basis import SubdomainFacetBasis
import numpy as np

m = MeshTri().refined(3).with_subdomains({
    'center': lambda x: (x[0] - 0.5) ** 2 + (x[1] - 0.5) ** 2 < 0.25 ** 2,
})
sfbasis = SubdomainFacetBasis(
    m,
    ElementTriP1(),
    elements='center',
)

@Functional
def plot_basis(w):
    import matplotlib.pyplot as plt
    fig,ax = plt.subplots(1,1,figsize=(6,6))
    pp = w.x.reshape(2,-1).T
    nn = w.n.reshape(2,-1).T
    for p, n  in zip(pp, nn):
        ax.arrow(*p, *n)
    plt.show()
    return w.x[0]

plot_basis.assemble(sfbasis)
```