### PR TITLE
restrict ex29 to MINI

### DIFF
--- a/docs/examples/ex24.py
+++ b/docs/examples/ex24.py
@@ -29,7 +29,7 @@ element = {'u': ElementVector(ElementTriP2()),
 basis = {variable: Basis(mesh, e, intorder=3)
          for variable, e in element.items()}
 
-D = basis['u'].get_dofs(mesh.boundaries)
+D = basis['u'].get_dofs(['inlet', 'ceiling', 'floor'])
 
 A = asm(vector_laplace, basis['u'])
 B = -asm(divergence, basis['u'], basis['p'])

--- a/docs/examples/ex24.py
+++ b/docs/examples/ex24.py
@@ -29,7 +29,7 @@ element = {'u': ElementVector(ElementTriP2()),
 basis = {variable: Basis(mesh, e, intorder=3)
          for variable, e in element.items()}
 
-D = basis['u'].get_dofs(['inlet', 'ceiling', 'floor'])
+D = basis['u'].get_dofs(mesh.boundaries)
 
 A = asm(vector_laplace, basis['u'])
 B = -asm(divergence, basis['u'], basis['p'])


### PR DESCRIPTION
This follows a weird-looking irrelevant change to the example in the review of #851.

When I first developed the example, I wasn't sure what element might be best to use for velocity but with experience `ElementLineMini` is a good choice.  This is also the obvious example in which one might want to use this element.