### PR TITLE
Add coo_data.solve, make assembly compatible with Pyodide

### DIFF
--- a/skfem/assembly/basis/cell_basis.py
+++ b/skfem/assembly/basis/cell_basis.py
@@ -3,7 +3,6 @@ from typing import Callable, Optional, Tuple
 
 import numpy as np
 from numpy import ndarray
-from scipy.sparse import coo_matrix
 from skfem.element import DiscreteField, Element
 from skfem.mapping import Mapping
 from skfem.mesh import Mesh
@@ -151,7 +150,7 @@ class CellBasis(AbstractBasis):
 
         return M, w.flatten()
 
-    def probes(self, x: ndarray) -> coo_matrix:
+    def probes(self, x: ndarray):
         """Return matrix which acts on a solution vector to find its values
         on points `x`.
 
@@ -162,6 +161,7 @@ class CellBasis(AbstractBasis):
         not assembled with the usual quadratures.
 
         """
+        from scipy.sparse import coo_matrix
 
         cells = self.mesh.element_finder(mapping=self.mapping)(*x)
         pts = self.mapping.invF(x[:, :, np.newaxis], tind=cells)

--- a/skfem/assembly/form/bilinear_form.py
+++ b/skfem/assembly/form/bilinear_form.py
@@ -5,7 +5,6 @@ from itertools import product
 
 import numpy as np
 from numpy import ndarray
-from scipy.sparse import csr_matrix
 
 from ..basis import Basis
 from .coo_data import COOData
@@ -128,7 +127,7 @@ class BilinearForm(Form):
             (vbasis.Nbfun, ubasis.Nbfun),
         )
 
-    def assemble(self, *args, **kwargs) -> csr_matrix:
+    def assemble(self, *args, **kwargs):
         """Assemble the bilinear form into a sparse matrix.
 
         Parameters

--- a/skfem/mesh/mesh_tet_1.py
+++ b/skfem/mesh/mesh_tet_1.py
@@ -3,7 +3,6 @@ from typing import Type
 
 import numpy as np
 from numpy import ndarray
-from scipy.spatial import cKDTree
 
 from ..element import Element, ElementTetP1
 from .mesh_3d import Mesh3D
@@ -36,6 +35,7 @@ class MeshTet1(MeshSimplex, Mesh3D):
             mapping = self._mapping()
 
         if not hasattr(self, '_cached_tree'):
+            from scipy.spatial import cKDTree
             self._cached_tree = cKDTree(np.mean(self.p[:, self.t], axis=1).T)
 
         tree = self._cached_tree

--- a/skfem/mesh/mesh_tri_1.py
+++ b/skfem/mesh/mesh_tri_1.py
@@ -3,7 +3,6 @@ from typing import Type
 
 import numpy as np
 from numpy import ndarray
-from scipy.spatial import cKDTree
 
 from ..element import Element, ElementTriP1
 from .mesh_2d import Mesh2D
@@ -381,6 +380,7 @@ class MeshTri1(MeshSimplex, Mesh2D):
             mapping = self._mapping()
 
         if not hasattr(self, '_cached_tree'):
+            from scipy.spatial import cKDTree
             self._cached_tree = cKDTree(np.mean(self.p[:, self.t], axis=1).T)
 
         tree = self._cached_tree

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,11 +3,11 @@ from unittest import TestCase
 import numpy as np
 from numpy.testing import assert_almost_equal
 
-from skfem.assembly import InteriorBasis
+from skfem.assembly import CellBasis
 from skfem.element import ElementTriP1
 from skfem.mesh import MeshTri
-from skfem.utils import projection, enforce
-from skfem.models import laplace, mass
+from skfem.utils import projection, enforce, condense, solve
+from skfem.models import laplace, mass, unit_load
 
 
 class InitializeScalarField(TestCase):
@@ -15,7 +15,7 @@ class InitializeScalarField(TestCase):
     def runTest(self):
 
         mesh = MeshTri().refined(5)
-        basis = InteriorBasis(mesh, ElementTriP1())
+        basis = CellBasis(mesh, ElementTriP1())
 
         def fun(X):
             x, y = X
@@ -38,7 +38,7 @@ class TestEnforce(TestCase):
 
         m = self.mesh
         e = ElementTriP1()
-        basis = InteriorBasis(m, e)
+        basis = CellBasis(m, e)
 
         A = laplace.assemble(basis)
         M = mass.assemble(basis)
@@ -50,3 +50,24 @@ class TestEnforce(TestCase):
 
         enforce(A, D=D, overwrite=True)
         assert_almost_equal(A.toarray(), np.eye(A.shape[0]))
+
+
+def test_simple_cg_solver():
+
+    m = MeshTri().refined(3)
+    basis = CellBasis(m, ElementTriP1())
+
+    A0 = laplace.coo_data(basis)
+    A1 = laplace.assemble(basis)
+
+    f = unit_load.assemble(basis)
+
+    D = m.boundary_nodes()
+
+    x1 = solve(*condense(A1, f, D=D))
+
+    f[D] = 0
+
+    x0 = A0.solve(f, D=D)
+
+    assert_almost_equal(x0, x1)


### PR DESCRIPTION
Pyodide doesn't support scipy 100%. I wanted to make the assembly parts of scikit-fem compatible with Pyodide in order to run scikit-fem inside a web browser. Thus, I moved some of the scipy imports into local scope.

Moreover, I added a simple pure-numpy conjugate gradient solver to `coo_data` in order to try out Pyodide.