### PR TITLE
Serialize oriented boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ with respect to documented and/or tested features.
   fields
 - Added: `Mesh.facets_around` which constructs a set of facets around a
   subdomain
-- Added: `Mesh.load` now tries loading the orientation of boundaries and
+- Added: `Mesh.save` and `load` now preserve the orientation of boundaries and
   interfaces
 - Added: `OrientedBoundary` which is a subclass of `ndarray` for facet index
   arrays with the orientation information (0 or 1 per facet) available as

--- a/skfem/mesh/mesh.py
+++ b/skfem/mesh/mesh.py
@@ -224,8 +224,8 @@ class Mesh:
         subdomains = {} if self._subdomains is None else self._subdomains
         boundaries = {} if self._boundaries is None else self._boundaries
 
-        def encode_boundary(
-            boundary: Union[ndarray, OrientedBoundary]) -> ndarray:
+        def encode_boundary(boundary: Union[ndarray, OrientedBoundary]
+                            ) -> ndarray:
             """return an array with an int per cell encoding a 'boundary'
 
             i.e. a subset of (optionally oriented) facets.

--- a/skfem/mesh/mesh.py
+++ b/skfem/mesh/mesh.py
@@ -224,7 +224,8 @@ class Mesh:
         subdomains = {} if self._subdomains is None else self._subdomains
         boundaries = {} if self._boundaries is None else self._boundaries
 
-        def encode_boundary(boundary: Union[ndarray, OrientedBoundary]) -> ndarray:
+        def encode_boundary(
+            boundary: Union[ndarray, OrientedBoundary]) -> ndarray:
             """return an array with an int per cell encoding a 'boundary'
 
             i.e. a subset of (optionally oriented) facets.
@@ -280,7 +281,7 @@ class Mesh:
                 subdomains[subnames[2]] = np.nonzero(data[0])[0]
             elif subnames[1] == "b":
                 mask = (
-                    (1 << np.arange(self.refdom.nfacets))[:, None] 
+                    (1 << np.arange(self.refdom.nfacets))[:, None]
                     & data[0].astype(int)
                 ).astype(bool)
                 facets = np.sort(self.t2f[mask])
@@ -289,7 +290,7 @@ class Mesh:
                 boundaries[subnames[2]] = (
                     OrientedBoundary(facets, ori) if ori.any() else facets
                 )
-    
+
         return boundaries, subdomains
 
     def boundary_nodes(self) -> ndarray:

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -7,7 +7,7 @@ import numpy as np
 from numpy.testing import assert_allclose, assert_almost_equal
 
 from skfem import BilinearForm, LinearForm, asm, solve, condense, projection
-from skfem.mesh import (MeshTri, MeshTet, MeshHex,
+from skfem.mesh import (Mesh, MeshTri, MeshTet, MeshHex,
                         MeshQuad, MeshLine1, MeshWedge1)
 from skfem.assembly import (CellBasis, FacetBasis, Dofs, Functional,
                             MortarFacetBasis)
@@ -599,20 +599,17 @@ def test_oriented_gauss_integral(m, e):
         decimal=5,
     )
 
+@pytest.mark.parametrize(
+    "m", [MeshLine1(), MeshTri(), MeshQuad(), MeshTet(), MeshHex()]
+)
+def test_oriented_saveload(m: Mesh):
 
-## TODO preserve orientation in save/load cycle
-# def test_oriented_saveload():
+    m = m.refined(4)
+    m = m.with_boundaries({"mid": m.facets_around([5]),})
+    assert len(m.boundaries["mid"].ori) == 3
 
-#     m = MeshTri().refined(4)
-#     m = m.with_boundaries({
-#         'mid': m.facets_around([5]),
-#     })
-#     assert len(m.boundaries['mid'].ori) == 3
+    M = from_meshio(to_meshio(m))
 
-#     # cycle to meshio and check that orientation is preserved
-#     M = from_meshio(to_meshio(m))
-
-#     assert_almost_equal(
-#         m.boundaries['mid'].ori,
-#         M.boundaries['mid'].ori,
-#     )
+    assert_almost_equal(
+        m.boundaries["mid"].ori, M.boundaries["mid"].ori,
+    )

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -4,7 +4,8 @@ from pathlib import Path
 
 import pytest
 import numpy as np
-from numpy.testing import assert_allclose, assert_almost_equal
+from numpy.testing import (assert_allclose, assert_almost_equal,
+                           assert_array_equal)
 
 from skfem import BilinearForm, LinearForm, asm, solve, condense, projection
 from skfem.mesh import (Mesh, MeshTri, MeshTet, MeshHex,
@@ -606,10 +607,10 @@ def test_oriented_saveload(m: Mesh):
 
     m = m.refined(4)
     m = m.with_boundaries({"mid": m.facets_around([5]),})
-    assert len(m.boundaries["mid"].ori) == 3
+    assert len(m.boundaries["mid"].ori) == m.refdom.nfacets
 
     M = from_meshio(to_meshio(m))
 
-    assert_almost_equal(
+    assert_array_equal(
         m.boundaries["mid"].ori, M.boundaries["mid"].ori,
     )

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -466,7 +466,7 @@ _test_lambda = {
 
 
 @pytest.mark.parametrize(
-    "internal_facets",
+    "boundaries_only",
     [
         True,
         False,
@@ -485,9 +485,9 @@ _test_lambda = {
         MeshTet2.load(MESH_PATH / 'quadraticsphere.msh'),
     ]
 )
-def test_meshio_cycle_boundaries(internal_facets, m):
+def test_meshio_cycle_boundaries(boundaries_only, m):
 
-    m = m.with_boundaries(_test_lambda, internal_facets)
+    m = m.with_boundaries(_test_lambda, boundaries_only)
     M = from_meshio(to_meshio(m))
     assert_array_equal(M.p, m.p)
     assert_array_equal(M.t, m.t)


### PR DESCRIPTION
As discussed in #873, the basic idea is that if facets are represented as the facet of the cell that they bound (as in `t2f`), as opposed to by the points that support them (as in `.facets`) then they are intrinsically oriented and already almost effectively serialized as oriented by #681; just a little more care has to be taken to handle awkward cases (as in `test_mesh.test_meshio_cycle_boundaries` which involves inconsistently oriented &ldquo;boundaries&rdquo;) and to infer the orientation on decoding.

This replaces botched attempts in #874 and #875.