### PR TITLE
allow projection of vector fields

### DIFF
--- a/skfem/assembly/basis/abstract_basis.py
+++ b/skfem/assembly/basis/abstract_basis.py
@@ -404,7 +404,7 @@ class AbstractBasis:
         from skfem.assembly import BilinearForm, LinearForm
         from skfem.helpers import inner
 
-        interp = self._normalize_interp(interp)
+        interp = np.array(self._normalize_interp(interp))
         if not isinstance(interp, tuple):
             interp = (interp,)
         assert len(interp) == len(self.basis[0])


### PR DESCRIPTION
I'm trying to project on a Basis which has a Vector, like the following:

```python
import numpy as np
import matplotlib.pyplot as plt

from skfem import *

mesh = MeshTri.init_tensor(x=np.linspace(-1, 1, 20), y=np.linspace(-1, 1, 20))

basis = Basis(mesh, ElementVector(ElementTriP1(), 2))

x = basis.project(lambda w: (w[1], -w[0]))

basis.plot(x)
plt.show()
```
Like this I get an error like
```python
  File ".../scikit-fem/skfem/assembly/basis/abstract_basis.py", line 410, in _projection
    assert len(interp) == len(self.basis[0])
AssertionError
```

This pull-request would fix this for this case, but it seems that it should be fixed somehow different.