### PR TITLE
fix meshio subdomain dtype

### DIFF
--- a/skfem/io/meshio.py
+++ b/skfem/io/meshio.py
@@ -109,7 +109,7 @@ def from_meshio(m,
 
     # parse any subdomains from cell_sets
     if m.cell_sets:
-        subdomains = {k: v[meshio_type]
+        subdomains = {k: v[meshio_type].astype(np.uint64)
                       for k, v in m.cell_sets_dict.items()
                       if meshio_type in v}
 


### PR DESCRIPTION
Somehow gmsh added a subdomain called "gmsh:bounding_entities" to my mesh and the dtype was int32. This created a problem after #1010 was merged.
(What exactly "gmsh:bounding_entities" is, is another question. But fixing the dtype should just avoid similar problems, too)