### PR TITLE
add multipoint constraint for generalized eigenproblems

### DIFF
--- a/skfem/mesh/mesh.py
+++ b/skfem/mesh/mesh.py
@@ -390,7 +390,7 @@ class Mesh:
 
         """
         midp = self.p[:, self.t].mean(axis=1)
-        return np.nonzero(test(midp))[0]
+        return np.nonzero(test(midp))[0].astype(np.uint64)
 
     def _expand_facets(self, ix: ndarray) -> Tuple[ndarray, ndarray]:
         """Return vertices and edges corresponding to given facet indices.


### PR DESCRIPTION
I've updated it to the latest version. With the "fixed equations"  in 8bbe102a272ac8d2dfa747054ac3c13001b2ce9f it doesn't work for ne, so I stayed with the previous ones.
I don't know yet how to include the `g`, so it's not yet included in the generalized case