### PR TITLE
add with-elements to cell_basis

### DIFF
--- a/skfem/assembly/basis/cell_basis.py
+++ b/skfem/assembly/basis/cell_basis.py
@@ -237,6 +237,16 @@ class CellBasis(AbstractBasis):
             elements=self.tind,
         )
 
+    def with_elements(self, elements: Optional[Any] = None) -> 'CellBasis':
+        """Return a similar basis on a subset of element indices."""
+        return type(self)(
+            self.mesh,
+            self.elem,
+            mapping=self.mapping,
+            quadrature=self.quadrature,
+            elements=elements,
+        )
+
     def boundary(self,
                  facets: Optional[Any] = None,
                  intorder: Optional[int] = None,


### PR DESCRIPTION
Like `with_element`, but for restricting the basis to a certain subset of elements.
Maybe there's a better name for the method to avoid confusion with `with_element` :thinking: 