### PR TITLE
Fix Mesh.refined()

### DIFF
--- a/skfem/mesh/mesh_tri_1.py
+++ b/skfem/mesh/mesh_tri_1.py
@@ -262,6 +262,8 @@ class MeshTri1(MeshSimplex, Mesh2D):
         ix12 = (l12 > l01) * (l12 > l02)
 
         # row swaps
+        t = t.copy()
+
         tmp = t[2, ix01]
         t[2, ix01] = t[1, ix01]
         t[1, ix01] = tmp


### PR DESCRIPTION
At the moment Mesh.refined(ix) changes also the current mesh as `t` is directly modified. If we use a copy here only the refined mesh is altered.