### PR TITLE
Add experimental.lab

### DIFF
--- a/skfem/experimental/lab/__init__.py
+++ b/skfem/experimental/lab/__init__.py
@@ -67,8 +67,7 @@ class Tensor:
 
     @property
     def T(self):
-        assert self.order == 2
-        return Tensor('transpose', self.order, [self])
+        return transpose(self)
 
     def __add__(self, other):
         otherc = _cast_tensor(other)
@@ -211,8 +210,11 @@ def _test_functions(elem, expr='v'):
             for i, e in enumerate(elems)]
 
 
-def symbols(elem):
-    return tuple(_trial_functions(elem) + _test_functions(elem))
+_ORDER_DICT = {
+    'x': 1,
+    'h': 0,
+    'n': 1,
+}
 
 
 @dataclass(repr=False)
@@ -220,6 +222,13 @@ class Coefficient(Tensor):
 
     def __repr__(self):
         return "w['" + self.expr + "']"
+
+
+def symbols(elem, **kwargs):
+    extra_outputs = ()
+    for key in kwargs:
+        extra_outputs += (Coefficient(key, order=_ORDER_DICT[key] if key in _ORDER_DICT else 0),)
+    return tuple(_trial_functions(elem) + _test_functions(elem)) + extra_outputs
 
 
 def div(a):
@@ -285,3 +294,8 @@ def minimum(a, b):
     bc = _cast_tensor(b)
     assert ac.order == 0 or bc.order == 0
     return Tensor('minimum', max(ac.order, bc.order), [ac, bc])
+
+
+def transpose(a):
+    assert a.order == 2
+    return Tensor('transpose', a.order, [a])

--- a/skfem/experimental/lab/__init__.py
+++ b/skfem/experimental/lab/__init__.py
@@ -1,4 +1,4 @@
-from skfem import *
+from skfem import *  # noqa
 from skfem import (BilinearForm,
                    LinearForm,
                    ElementVector,
@@ -206,7 +206,7 @@ def _test_functions(elem, expr='v'):
     else:
         elems = [elem]
     tests = ['{}{}'.format(expr, i + 1)
-              for i, e in enumerate(elems)]
+             for i, e in enumerate(elems)]
     return [Tensor(tests[i], order=_find_order(e), test=tests)
             for i, e in enumerate(elems)]
 

--- a/skfem/experimental/lab/__init__.py
+++ b/skfem/experimental/lab/__init__.py
@@ -1,0 +1,252 @@
+from skfem import *
+from skfem.experimental.autodiff import NonlinearForm
+import numpy as np
+from dataclasses import dataclass
+from typing import List, Optional
+from itertools import chain
+
+
+@dataclass
+class Tensor:
+    expr: str
+    order: int = 0
+    args: Optional[List] = None
+    dyadic: bool = False
+    trial: Optional[List] = None
+    test: Optional[List] = None
+
+    def __iter__(self):
+        if self.args is not None:
+            for v in chain.from_iterable(self.args):
+                yield v
+        yield self
+
+    def __repr__(self):
+        if self.args is not None:
+            if self.dyadic:
+                assert len(self.args) == 2
+                return ('('
+                        + repr(self.args[0])
+                        + self.expr
+                        + repr(self.args[1])
+                        + ')')
+            return (self.expr
+                    + '('
+                    + ','.join(map(lambda x: repr(x), self.args))
+                    + ')')
+        return self.expr
+
+    def _legacy_repr(self):
+        out = str(self)
+        for p in self._params():
+            out = out.replace('grad({})'.format(p), 'GRAD')
+            out = out.replace('div({})'.format(p), 'DIV')
+            out = out.replace(p, p + "[0]")
+            out = out.replace('GRAD', 'grad({})'.format(p))
+            out = out.replace('DIV', 'div({})'.format(p))
+        return out
+
+    def _trial_params(self):
+        for t in self:
+            if t.trial is not None:
+                return t.trial
+        return []
+
+    def _test_params(self):
+        for t in self:
+            if t.test is not None:
+                return t.test
+        return []
+
+    def _params(self) -> str:
+        return [] + self._trial_params() + self._test_params()
+
+    @property
+    def T(self):
+        assert self.order == 2
+        return Tensor('transpose', self.order, [self])
+
+    def __add__(self, other):
+        assert self.order == other.order
+        return Tensor('+', self.order, [self, other], True)
+
+    def __sub__(self, other):
+        assert self.order == other.order
+        return Tensor('-', self.order, [self, other], True)
+
+    def __mul__(self, other):
+        if isinstance(other, float) or isinstance(other, int):
+            other = Tensor(repr(other), order=0)
+        assert self.order == 0 or other.order == 0
+        return Tensor('*', max(self.order, other.order), [self, other], True)
+
+    def __rmul__(self, other):
+        return self * other
+
+    def __matmul__(self, other):
+        return mul(self, other)
+
+    def __getitem__(self, key):
+        assert self.order > 0
+        assert isinstance(key, int)
+        assert key >= 0
+        return Tensor('_', self.order - 1, [self, Tensor(repr(key), order=0)])
+
+    def assemble(self, *args, **kwargs):
+        assert self.order == 0
+        if 'x' in kwargs:
+            x = kwargs['x']
+            del kwargs['x']
+            if len(self._test_params()) == 0:
+                return NonlinearForm(hessian=True)(
+                    self._as_legacy_fun()
+                ).assemble(*args, x=x, **kwargs)
+            return (NonlinearForm(self._as_legacy_fun())
+                    .assemble(*args, x=x, **kwargs))
+        if len(self._trial_params()) == 0:
+            return LinearForm(self._as_fun()).assemble(*args, **kwargs)
+        return BilinearForm(self._as_fun()).assemble(*args, **kwargs)
+
+    def _as_fun(self):
+        from skfem.helpers import (dot,
+                                   ddot,
+                                   grad,
+                                   div,
+                                   transpose,
+                                   trace,
+                                   mul,
+                                   eye)
+        scope = {}
+        params = ','.join(self._params() + ['w']) + ':'
+        exec('fun=lambda ' + params + str(self),
+             {'dot': dot,
+              'ddot': ddot,
+              'grad': grad,
+              'div': div,
+              'transpose': transpose,
+              'trace': trace,
+              'sin': np.sin,
+              'cos': np.cos,
+              'tan': np.tan,
+              'mul': mul,
+              'eye': eye,
+              '_': lambda a, i: a[i]},
+             scope)
+        return scope['fun']
+
+    def _as_legacy_fun(self):
+        from skfem.experimental.autodiff.helpers import (dot,
+                                                         ddot,
+                                                         grad,
+                                                         div,
+                                                         transpose,
+                                                         trace,
+                                                         mul,
+                                                         eye)
+        import autograd.numpy as anp
+        scope = {}
+        params = ','.join(self._params() + ['w']) + ':'
+        exec('fun=lambda ' + params + self._legacy_repr(),
+             {'dot': dot,
+              'ddot': ddot,
+              'grad': grad,
+              'div': div,
+              'transpose': transpose,
+              'trace': trace,
+              'sin': anp.sin,
+              'cos': anp.cos,
+              'tan': anp.tan,
+              'mul': mul,
+              'eye': eye,
+              '_': lambda a, i: a[i]},
+             scope)
+        return scope['fun']
+
+    def coo_data(self, *args, **kwargs):
+        NotImplementedError
+
+
+def _find_order(elem):
+    if isinstance(elem, ElementVector):
+        return 1
+    return 0
+
+
+def _trial_functions(elem, expr='u'):
+    if isinstance(elem, ElementComposite):
+        elems = elem.elems
+    else:
+        elems = [elem]
+    trials = ['{}{}'.format(expr, i + 1)
+              for i, e in enumerate(elems)]
+    return [Tensor(trials[i], order=_find_order(e), trial=trials)
+            for i, e in enumerate(elems)]
+
+
+def _test_functions(elem, expr='v'):
+    if isinstance(elem, ElementComposite):
+        elems = elem.elems
+    else:
+        elems = [elem]
+    tests = ['{}{}'.format(expr, i + 1)
+              for i, e in enumerate(elems)]
+    return [Tensor(tests[i], order=_find_order(e), test=tests)
+            for i, e in enumerate(elems)]
+
+
+def symbols(elem):
+    return tuple(_trial_functions(elem) + _test_functions(elem))
+
+
+@dataclass(repr=False)
+class Coefficient(Tensor):
+
+    def __repr__(self):
+        return "w['" + self.expr + "']"
+
+
+def div(a):
+    assert a.order >= 1
+    return Tensor('div', a.order - 1, [a])
+
+
+def grad(a):
+    return Tensor('grad', a.order + 1, [a])
+
+
+def dot(a, b):
+    assert a.order == 1
+    assert b.order == 1
+    return Tensor('dot', 0, [a, b])
+
+
+def ddot(a, b):
+    assert a.order == 2
+    assert b.order == 2
+    return Tensor('ddot', 0, [a, b])
+
+
+def sin(a):
+    return Tensor('sin', a.order, [a])
+
+def cos(a):
+    return Tensor('cos', a.order, [a])
+
+def tan(a):
+    return Tensor('tan', a.order, [a])
+
+
+def trace(a):
+    assert a.order == 2
+    return Tensor('trace', 0, [a])
+
+tr = trace
+
+def eye(w, n):
+    return Tensor('eye', 2, [w, Tensor(str(n))])
+
+
+def mul(a, b):
+    assert ((a.order == 2 and b.order == 1)
+            or (a.order == 2 and b.order == 2))
+    return Tensor('mul', b.order, [a, b])

--- a/tests/test_lab.py
+++ b/tests/test_lab.py
@@ -1,0 +1,35 @@
+import pytest
+
+from numpy.testing import assert_array_almost_equal
+from skfem.assembly import Basis, BilinearForm
+from skfem.element import ElementTriP1, ElementVector
+from skfem.mesh import MeshTri, MeshTet
+from skfem.experimental.lab import symbols
+
+
+@pytest.mark.parametrize(
+    "form,m,elem",
+    [
+        ("dot(grad(u), grad(v))", MeshTri().refined(), ElementTriP1()),
+        ("u * v", MeshTri().refined(), ElementTriP1()),
+        ("u[0] * v[0]", MeshTri().refined(), ElementVector(ElementTriP1())),
+    ]
+)
+def test_compare_forms(form, m, elem):
+
+    basis = Basis(m, elem)
+
+    @BilinearForm
+    def form1(u, v, w):
+        from skfem.helpers import dot, grad
+        return eval(form)
+
+    def form2():
+        from skfem.experimental.lab import dot, grad
+        u, v = symbols(elem)
+        return eval(form)
+
+    A1 = BilinearForm(form1).assemble(basis).todense()
+    A2 = form2().assemble(basis).todense()
+
+    assert_array_almost_equal(A1, A2)


### PR DESCRIPTION
Work on experimental and optional symbolic "language" for defining weak forms. This requires `autograd` and is continuation of my past work on automatic differentiation.

Some examples:
```python
"""Navier-Stokes lid driven cavity."""
from skfem.experimental.lab import *
import numpy as np


m = MeshTri().refined(4)

elem = ElementVector(ElementTriP2()) * ElementTriP1()
basis = Basis(m, elem)

u, p, v, q = symbols(elem)

form = (ddot(grad(u), grad(v))
        + dot(mul(grad(u), u), v)
        - p * div(v)
        - q * div(u)
        - 1e-3 * p * q)

x = basis.zeros()
for itr in range(20):
    x[basis.get_dofs('top').all('u^1^1')] = 100.
    dt = solve(*condense(*form.assemble(basis, x=x),
                         D=basis.get_dofs().all(['u^1^1', 'u^2^1'])))
    x += dt
    print(np.linalg.norm(dt))

(u, ubasis), (p, pbasis) = basis.split(x)

pbasis.plot(p).show()
ubasis.plot(u).show()
```
```python
"""Nonlinear elasticity."""
from skfem.experimental.lab import *
import numpy as np


m = MeshQuad.init_tensor(np.linspace(0, 5, 20),
                         np.linspace(0, 0.5, 5))

elem = ElementVector(ElementQuad1())
basis = Basis(m, elem)

u, _ = symbols(elem)

epsu = .5 * (grad(u) + grad(u).T + grad(u).T @ grad(u))
sigu = epsu + eye(tr(epsu), 2)
form = ddot(sigu, epsu) - 1e-5 * u[1]

x = basis.zeros()
for itr in range(20):
    x[basis.get_dofs('right').all('u^1')] = -np.minimum(itr, 10) / 20
    x[basis.get_dofs('right').all('u^2')] = 0
    dt = solve(*condense(*form.assemble(basis, x=x),
                         D=basis.get_dofs({'left', 'right'}).all()))
    x += dt
    print(np.linalg.norm(dt))

mdefo = m.translated(x[basis.nodal_dofs])
ax = m.draw(color='r')
mdefo.draw(ax=ax).show()
```