### PR TITLE
Fixes for numpy 2.0

### DIFF
--- a/skfem/assembly/dofs.py
+++ b/skfem/assembly/dofs.py
@@ -444,7 +444,7 @@ class Dofs:
             nodal_ix,
             facet_ix,
             edge_ix,
-            np.empty((0,), dtype=np.uint64),
+            np.empty((0,), dtype=np.int64),
             r1,
             r2,
             r3,

--- a/skfem/io/meshio.py
+++ b/skfem/io/meshio.py
@@ -111,7 +111,7 @@ def from_meshio(m,
 
     # parse any subdomains from cell_sets
     if m.cell_sets:
-        subdomains = {k: v[meshio_type].astype(np.uint64)
+        subdomains = {k: v[meshio_type].astype(np.int64)
                       for k, v in m.cell_sets_dict.items()
                       if meshio_type in v}
 

--- a/skfem/mesh/mesh.py
+++ b/skfem/mesh/mesh.py
@@ -271,7 +271,8 @@ class Mesh:
         return {
             **{
                 f"skfem:s:{name}": [
-                    np.isin(np.arange(self.t.shape[1], dtype=np.int64), subdomain).astype(int)
+                    np.isin(np.arange(self.t.shape[1],
+                                      dtype=np.int64), subdomain).astype(int)
                 ]
                 for name, subdomain in subdomains.items()
             },

--- a/skfem/mesh/mesh.py
+++ b/skfem/mesh/mesh.py
@@ -152,7 +152,7 @@ class Mesh:
         A = self.edges[:, edge_candidates].T
         B = boundary_edges
         dims = A.max(0) + 1
-        ix = np.where(np.in1d(
+        ix = np.where(np.isin(
             np.ravel_multi_index(A.T, dims),  # type: ignore
             np.ravel_multi_index(B.T, dims),  # type: ignore
         ))[0]
@@ -271,7 +271,7 @@ class Mesh:
         return {
             **{
                 f"skfem:s:{name}": [
-                    np.isin(np.arange(self.t.shape[1]), subdomain).astype(int)
+                    np.isin(np.arange(self.t.shape[1], dtype=np.int64), subdomain).astype(int)
                 ]
                 for name, subdomain in subdomains.items()
             },
@@ -295,7 +295,7 @@ class Mesh:
             elif subnames[1] == "b":
                 mask = (
                     (1 << np.arange(self.refdom.nfacets))[:, None]
-                    & data[0].astype(int)
+                    & data[0].astype(np.int64)
                 ).astype(bool)
                 facets = np.sort(self.t2f[mask])
                 cells = mask.nonzero()[1]
@@ -399,7 +399,7 @@ class Mesh:
 
         """
         midp = self.p[:, self.t].mean(axis=1)
-        return np.nonzero(test(midp))[0].astype(np.uint64)
+        return np.nonzero(test(midp))[0].astype(np.int64)
 
     def _expand_facets(self, ix: ndarray) -> Tuple[ndarray, ndarray]:
         """Return vertices and edges corresponding to given facet indices.

--- a/skfem/mesh/mesh_3d.py
+++ b/skfem/mesh/mesh_3d.py
@@ -43,7 +43,7 @@ class Mesh3D(Mesh):
         A = self.edges[:, edge_candidates].T
         B = boundary_edges
         dims = A.max(0) + 1
-        ix = np.where(np.in1d(
+        ix = np.where(np.isin(
             np.ravel_multi_index(A.T, dims),  # type: ignore
             np.ravel_multi_index(B.T, dims),  # type: ignore
         ))[0]

--- a/tests/test_dofs.py
+++ b/tests/test_dofs.py
@@ -48,7 +48,7 @@ class TestDofsNodalSubsets(TestCase):
         self.assertEqual(len(all_dofs.drop('u').facet), 1)
 
         all_dofs = basis.dofs.get_facet_dofs(
-            m.facets_satisfying(lambda x: 1))
+            m.facets_satisfying(lambda x: 1 + x[0] * 0))
 
         self.assertEqual(len(all_dofs.keep('u_n').facet), 1)
         self.assertEqual(len(all_dofs.drop('u').facet), 1)


### PR DESCRIPTION
Makes sure that test suite runs (without the parts that depend on meshio and matplotlib which both are currently broken with numpy==2) with numpy==2 nightly build.

- Changed all occurences of np.is1d to np.isin
- Made sure that inputs to np.isin are of type np.int64 and not np.uint64

Note that meshio does not currently work with numpy==2 because of removed functionality. Because meshio is an optional dependency of scikit-fem, I don't currently plan to enforce numpy<2 here. Even though meshio is inactive, fix to meshio is quite easy (replacing some np.string_ with np.bytes_) so perhaps it will happen.

It is still possible that some code breaks because we do not guard against stuff like np.uint64 going into np.isin and other functions used within scikit-fem that will be, for some reason, more stricter of their type in numpy==2. It is not entirely clear to me what change in numpy==2 causes this, and it might even be a bug because I am testing against a nightly build.