### PR TITLE
fix split_bases and split_indices for ElementVector

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 with respect to documented and/or tested features.
 
+### Unreleased
+
+- Fixed: `ElementVector` works also for split_bases/split_indices in case `mesh.dim() != elem.dim`
+
 ### [9.0.0] - 2023-12-24
 
 - Removed: Python 3.7 support
@@ -236,7 +240,6 @@ with respect to documented and/or tested features.
   `MeshTet2` and `MeshHex2`
 - Fixed: `ElementGlobal` now uses outward normals to initialize DOFs
   on boundary facets
-- Fixed: `ElementVector` works also for split_bases/split_indices in case `mesh.dim() != elem.dim`
 
 ### [8.1.0] - 2023-06-16
 

--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ with respect to documented and/or tested features.
   `MeshTet2` and `MeshHex2`
 - Fixed: `ElementGlobal` now uses outward normals to initialize DOFs
   on boundary facets
+- Fixed: `ElementVector` works also for split_bases/split_indices in case `mesh.dim() != elem.dim`
 
 ### [8.1.0] - 2023-06-16
 

--- a/skfem/assembly/basis/abstract_basis.py
+++ b/skfem/assembly/basis/abstract_basis.py
@@ -338,7 +338,7 @@ class AbstractBasis:
                                e.interior_dofs])
             return output
         elif isinstance(self.elem, ElementVector):
-            ndims = self.mesh.dim()
+            ndims = self.elem.dim
             e = self.elem.elem
             for k in range(ndims):
                 output.append(np.concatenate((
@@ -359,7 +359,7 @@ class AbstractBasis:
         elif isinstance(self.elem, ElementVector):
             return [type(self)(self.mesh, self.elem.elem, self.mapping,
                                quadrature=self.quadrature)
-                    for _ in range(self.mesh.dim())]
+                    for _ in range(self.elem.dim)]
         return [self]
 
     @property


### PR DESCRIPTION
At those two lines it should be the number of dimensions of the `ElementVector` not the number of dimensions of the mesh, right?
(I'm having a 3D vector in a 2D mesh)