### PR TITLE
Fix Mesh.p2e

### DIFF
--- a/skfem/mesh/mesh.py
+++ b/skfem/mesh/mesh.py
@@ -174,6 +174,19 @@ class Mesh:
     @property
     def p2e(self):
         """Incidence matrix between edges and vertices."""
+        from scipy.sparse import coo_matrix
+        edges = self.edges.flatten('C')
+        return coo_matrix(
+            (np.ones(len(edges), dtype=np.int32),
+             (np.concatenate((np.arange(self.nedges),)
+                             * self.edges.shape[0]), edges)),
+            shape=(self.nedges, self.nvertices),
+            dtype=np.int32,
+        ).tocsc()
+
+    @property
+    def e2t(self):
+        """Incidence matrix between elements and edges."""
         p2t = self.p2t
         edges = self.edges
         return p2t[:, edges[0]].multiply(p2t[:, edges[1]])

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -793,17 +793,18 @@ def test_incidence(mesh):
     for itr in range(0, 50, 3):
         assert np.sum((mesh.facets == itr).any(axis=0)) == len(p2f[:, itr].data)
 
-    p2e = mesh.p2e
-    for itr in range(0, 50, 3):
-        assert np.sum((mesh.edges == itr).any(axis=0)) == len(p2e[:, itr].data)
+    if isinstance(mesh, (MeshTet1, MeshHex1)):
+        p2e = mesh.p2e
+        for itr in range(0, 50, 3):
+            assert np.sum((mesh.edges == itr).any(axis=0)) == len(p2e[:, itr].data)
 
-    e2t = mesh.e2t
-    for itr in range(0, 50, 3):
-        e = mesh.edges[:, itr]
-        datalen = np.sum(
-            (mesh.t == e[0]).any(axis=0) & (mesh.t == e[1]).any(axis=0)
-        )
-        assert datalen == len(e2t[:, itr].data)
+        e2t = mesh.e2t
+        for itr in range(0, 50, 3):
+            e = mesh.edges[:, itr]
+            datalen = np.sum(
+                (mesh.t == e[0]).any(axis=0) & (mesh.t == e[1]).any(axis=0)
+            )
+            assert datalen == len(e2t[:, itr].data)
 
 def test_restrict_tags_boundary():
 

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -7,8 +7,8 @@ from scipy.spatial import Delaunay
 from numpy.testing import assert_array_equal, assert_almost_equal
 
 from skfem.mesh import (Mesh, MeshHex, MeshLine, MeshQuad, MeshTet, MeshTri,
-                        MeshTri2, MeshQuad2, MeshTet2, MeshHex2, MeshLine1DG,
-                        MeshQuad1DG, MeshHex2, MeshTri1DG)
+                        MeshTet1, MeshHex1, MeshLine1DG, MeshQuad1DG, 
+                        MeshTri1DG, MeshTri2, MeshQuad2, MeshTet2, MeshHex2)
 from skfem.assembly import Basis, LinearForm, Functional, FacetBasis
 from skfem.element import (ElementTetP1, ElementTriP0, ElementQuad0,
                            ElementHex0)

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -787,12 +787,23 @@ def test_incidence(mesh):
 
     p2t = mesh.p2t
     for itr in range(0, 50, 3):
-       assert np.sum((mesh.t == itr).any(axis=0)) == len(p2t[:, itr].data)
+        assert np.sum((mesh.t == itr).any(axis=0)) == len(p2t[:, itr].data)
 
     p2f = mesh.p2f
     for itr in range(0, 50, 3):
-       assert np.sum((mesh.facets == itr).any(axis=0)) == len(p2f[:, itr].data)
+        assert np.sum((mesh.facets == itr).any(axis=0)) == len(p2f[:, itr].data)
 
+    p2e = mesh.p2e
+    for itr in range(0, 50, 3):
+        assert np.sum((mesh.edges == itr).any(axis=0)) == len(p2e[:, itr].data)
+
+    e2t = mesh.e2t
+    for itr in range(0, 50, 3):
+        e = mesh.edges[:, itr]
+        datalen = np.sum(
+            (mesh.t == e[0]).any(axis=0) & (mesh.t == e[1]).any(axis=0)
+        )
+        assert datalen == len(e2t[:, itr].data)
 
 def test_restrict_tags_boundary():
 


### PR DESCRIPTION
The `Mesh.p2e` (vertices to edges) method functioned actually as `Mesh.e2t `(edges to elements). I renamed the original method as `e2t` and added a new method `p2e` that produces a map between vertices and edges.

This might have slipped as there were no test cases for `Mesh.p2e `beforehand. I added cases for both `p2e` and `e2t`, and fixed the indentation of the other cases for that particular test.