### PR TITLE
Make interpolator work for vector valued base functions

### DIFF
--- a/skfem/assembly/basis/cell_basis.py
+++ b/skfem/assembly/basis/cell_basis.py
@@ -190,15 +190,20 @@ class CellBasis(AbstractBasis):
                 for k in range(self.Nbfun)
             ]
         ).flatten()
+        #number of components of the current base functions
+        try:
+            comp=len(self.elem.lbasis(self.elem.dim*[0],0)[0])
+        except:    
+            comp=1
         return coo_matrix(
             (
                 phis,
                 (
-                    np.tile(np.arange(x.shape[1]), self.Nbfun),
-                    self.element_dofs[:, cells].flatten(),
+                    np.tile(np.arange(comp*x.shape[1]), self.Nbfun),
+                    self.element_dofs[:, np.tile(cells,comp)].flatten(),
                 ),
             ),
-            shape=(x.shape[1], self.N),
+            shape=(comp*x.shape[1], self.N),
         )
 
     def point_source(self, x: ndarray) -> ndarray:


### PR DESCRIPTION
With the interpolator function the value of an expansion at multiple x can be calculated according to

$f(x)=\sum\limits_{n=1}^{dofs} a_n \phi_n(x)$. 

      poi=np.array([[0.3,0.4],[1.2,0.4],[1.2,1.6],[0.3,1.6]])
      tri=np.array([[0,1,2],[3,0,2]])
      mesh = fem.MeshTri(poi.T, tri.T)      
      e=fem.ElementTriP1()
      Vh = fem.Basis(mesh,e)
      xx=np.array([[0.8,0.5],[0.7,1.2]])
      aj=[1,0,0,0]
      interp = Vh.interpolator(aj)
      val = interp(xx)
      print(val)

However for vector valued base functions ( e.g. e=fem.ElementTriN1() ) this does not work

      ValueError: row, column, and data array must all be the same length
The error is due to the fact that the rows and cols are not correctly assembled.

This pull request fixes the error. In cell_basis.py the probes() function returns a matrix. The rows refer to the different points in the array xx, the cols refer to the dof-values. 
In the fixed version the rows are simply extended by the additional components, so the first k (k number of points the sum has to calculate) rows belong to the first component, the next k rows to the second component and so on.
The following code is an example for Nedelec, first order in a triangle.

      import matplotlib.pyplot as plt
      import skfem as fem
      import numpy as np
      poi=np.array([[0.3,0.4],[1.2,0.4],[1.2,1.6],[0.3,1.6]])
      tri=np.array([[0,1,2],[3,0,2]])

      mesh = fem.MeshTri(poi.T, tri.T)      
      e=fem.ElementTriN1()
      Vh = fem.Basis(mesh,e)

      N=13
      aa=np.linspace(0.3,1.2,N)
      bb=np.linspace(0.4,1.6,N)
      xv, yv = np.meshgrid(aa, bb)
      xx=np.array([xv.flatten(),yv.flatten()])

      plt.figure(figsize=(8, 12))
      aj=Vh.dofs.N*[0]
      # change ii
      ii=1
      aj[ii]=1

      interp = Vh.interpolator(aj)
      val = interp(xx)
      qq=val.reshape(2,-1)

      plt.quiver(xx[0],xx[1],qq[0],qq[1])
      plt.triplot(mesh.p[0],mesh.p[1],mesh.t.T)
      plt.axis('equal')
      x0=Vh.doflocs[0][ii]
      y0=Vh.doflocs[1][ii]
      plt.plot(x0,y0,'or',ms=7,label='dof')
      plt.legend()
      plt.show()

I was not able to find a parameter that directly gives the number of components of a element or base, so it is determined in a first step by calculating the first basefunction at the origin of the local coordinate system and counting the number of values. Then the matrix is restructured using the phis and the number of components as described above.
The values returned after the matrix vector multiplication are therefore ordered in the same way. Currently they are not yet reshaped. 

remarks

1) If there is a parameter like number_of_components I did not see 
      comp = len(self.elem.lbasis(self.elem.dim*[0],0)[0])
could be replaced

2) In the example above the returned array val is reshaped externally to separate the components. This could be done also in the interpolator function. A comp parameter would be helpful here too. 







  