### PR TITLE
Read integer cell tags from `meshio` object

### DIFF
--- a/skfem/io/meshio.py
+++ b/skfem/io/meshio.py
@@ -116,63 +116,90 @@ def from_meshio(m,
     subdomains = {}
     boundaries = {}
 
-    # parse any subdomains from cell_sets
-    if m.cell_sets:
-        subdomains = {k: v[meshio_type].astype(np.int32)
-                      for k, v in m.cell_sets_dict.items()
-                      if meshio_type in v}
+    ###################################################################################
+    # NOTE: Create a cell_index_dict dictionary that holds the name of the physical
+    # region, element type, and element indices using the form:
+    # {region: {element type: element indices}}
+
+    # HACK: only the "names" of the physical groups are read
+    cell_index_dict = {k: v for k, v in m.cell_sets_dict.items() if "gmsh" not in k}
+
+    # HACK: check if tags are provided to the mesh as integer cell functions.
+    # If so, load them as cell_index_dict. This is tested for Gmsh 4.1 msh files,
+    # and Salome med files.
+    if not cell_index_dict:
+        subdomain_tag_key = None
+        for key in ["gmsh:physical", "cell_tags"]:
+            if key in m.cell_data_dict:
+                subdomain_tag_key = key
+                break
+        if subdomain_tag_key:
+            cell_type_dict = m.cell_data_dict[subdomain_tag_key]
+            for k, v in cell_type_dict.items():
+                unique_tags = np.unique(v)
+                for tag in unique_tags:
+                    name_tag = (
+                        m.cell_tags[tag][0]
+                        if (hasattr(m, "cell_tags") and (tag in m.cell_tags))
+                        else int(tag)
+                    )
+                    if name_tag not in cell_index_dict:
+                        cell_index_dict[name_tag] = {k: np.where(v == tag)[0]}
+                    else:
+                        cell_index_dict[name_tag].update({k: np.where(v == tag)[0]})
 
     # create temporary mesh for matching boundary elements
     mtmp = mesh_type(p, t, validate=False)
     bnd_type = BOUNDARY_TYPE_MAPPING[meshio_type]
 
-    # parse boundaries from cell_sets
-    if m.cell_sets and bnd_type in m.cells_dict:
-        p2f = mtmp.p2f
-        for k, v in m.cell_sets_dict.items():
-            if bnd_type in v and k.split(":")[0] != "gmsh":
-                facets = m.cells_dict[bnd_type][v[bnd_type]].T
-                sorted_facets = np.sort(facets, axis=0)
-                ind = p2f[:, sorted_facets[0]]
-                for itr in range(sorted_facets.shape[0] - 1):
-                    ind = ind.multiply(p2f[:, sorted_facets[itr + 1]])
-                # does not preserve order:
-                # boundaries[k] = np.nonzero(ind)[0].astype(np.int32)
-                ii, jj = ind.nonzero()
-                boundaries[k] = ii[np.argsort(jj)]
+    for k, v in cell_index_dict.items():
+        # parse any subdomains
+        if meshio_type in v:
+            subdomains[k] = v[meshio_type]
 
-                if not ignore_orientation:
-                    try:
-                        ori = np.zeros_like(boundaries[k], dtype=np.float64)
-                        t1, t2 = mtmp.f2t[:, boundaries[k]]
-                        if facets.shape[0] == 2:
-                            tangents = (mtmp.p[:, facets[1]]
-                                        - mtmp.p[:, facets[0]])
-                            normals = np.array([-tangents[1], tangents[0]])
-                        elif facets.shape[0] == 3:
-                            tangents1 = (mtmp.p[:, facets[1]]
-                                         - mtmp.p[:, facets[0]])
-                            tangents2 = (mtmp.p[:, facets[2]]
-                                         - mtmp.p[:, facets[0]])
-                            normals = -np.cross(tangents1.T, tangents2.T).T
-                        else:
-                            raise NotImplementedError
-                        # perform a dot product between the proposed normal
-                        # and the edges of the element to fix the orientation
-                        for itr in range(mtmp.t.shape[0]):
-                            ori += np.sum(normals
-                                          * (mtmp.p[:, facets[0]]
-                                             - mtmp.p[:, mtmp.t[itr, t1]]),
-                                          axis=0)
-                        ori = 1 * (ori > 0)
-                        # check that the orientation is not 'illegal'
-                        # this might happen for a hole
-                        # as a consequence, choose the only valid ori
-                        ori[t2 == -1] = 0
-                        boundaries[k] = OrientedBoundary(boundaries[k],
-                                                         ori)
-                    except Exception:
-                        logger.warning("Failure to orient a boundary.")
+        # parse boundaries
+        if bnd_type in v:
+            p2f = mtmp.p2f
+            facets = m.cells_dict[bnd_type][v[bnd_type]].T
+            sorted_facets = np.sort(facets, axis=0)
+            ind = p2f[:, sorted_facets[0]]
+            for itr in range(sorted_facets.shape[0] - 1):
+                ind = ind.multiply(p2f[:, sorted_facets[itr + 1]])
+            # does not preserve order:
+            # boundaries[k] = np.nonzero(ind)[0].astype(np.int32)
+            ii, jj = ind.nonzero()
+            boundaries[k] = ii[np.argsort(jj)]
+
+            if not ignore_orientation:
+                try:
+                    ori = np.zeros_like(boundaries[k], dtype=np.float64)
+                    t1, t2 = mtmp.f2t[:, boundaries[k]]
+                    if facets.shape[0] == 2:
+                        tangents = mtmp.p[:, facets[1]] - mtmp.p[:, facets[0]]
+                        normals = np.array([-tangents[1], tangents[0]])
+                    elif facets.shape[0] == 3:
+                        tangents1 = mtmp.p[:, facets[1]] - mtmp.p[:, facets[0]]
+                        tangents2 = mtmp.p[:, facets[2]] - mtmp.p[:, facets[0]]
+                        normals = -np.cross(tangents1.T, tangents2.T).T
+                    else:
+                        raise NotImplementedError
+                    # perform a dot product between the proposed normal
+                    # and the edges of the element to fix the orientation
+                    for itr in range(mtmp.t.shape[0]):
+                        ori += np.sum(
+                            normals
+                            * (mtmp.p[:, facets[0]] - mtmp.p[:, mtmp.t[itr, t1]]),
+                            axis=0,
+                        )
+                    ori = 1 * (ori > 0)
+                    # check that the orientation is not 'illegal'
+                    # this might happen for a hole
+                    # as a consequence, choose the only valid ori
+                    ori[t2 == -1] = 0
+                    boundaries[k] = OrientedBoundary(boundaries[k], ori)
+                except Exception:
+                    logger.warning("Failure to orient a boundary.")
+#######################################################################################
 
     # MSH 2.2 tag parsing
     if len(boundaries) == 0 and m.cell_data and m.field_data:


### PR DESCRIPTION
First, I would like to thank you for this great package. It has made finite-element analysis using python array libraries, like NumPy and JAX, a breeze!

We are a pan European project, funded by the European Union, to develop multi-scale modelling suite for magnetic materials that brings together simulations, experimental data, and AI. Our aim is to offer a comprehensive software suite for everything from first principle calculations to device-level modeling for magnetic materials. Beyond advancing scientific understanding, our aim is to support sustainability goals by focusing on greener magnets, while fostering open source development. You can read further about the MaMMoS project here: https://mammos-project.github.io

We intend to use `scikit-fem` for finite-element assembly in our micromagnetic simulation software. However, it is not possible to read integer mesh tags from both Gmsh (`.msh`) and Salome (`.med`) files at present. This PR is an attempt to fix the above mentioned problem.

## What is the problem?
We fail to retrieve integer mesh tags using `skfem.Mesh.load` method. Consider the following mesh generation code using Gmsh:
```Python
import gmsh

gmsh.initialize()
gmsh.model.add("Sphere")

sphere = gmsh.model.occ.add_sphere(0, 0, 0, 10)

gmsh.model.occ.synchronize()

boundary = gmsh.model.get_boundary([(3, sphere)])
boundary_tag = boundary[0][1]

# No name given to the physical groups
gmsh.model.add_physical_group(3, [sphere], tag=1)
gmsh.model.add_physical_group(2, [boundary_tag], tag=2)

gmsh.model.mesh.set_size(gmsh.model.get_entities(0), 8)

gmsh.model.mesh.generate(3)
gmsh.write("sphere.msh")
gmsh.finalize()
```
This will create a sphere of radius 10 and tag the volume of the sphere as 1 and the boundary as 2. Using `skfem` to read the mesh:

```Console
Python 3.13.5 | packaged by conda-forge | (main, Jun 16 2025, 08:27:50) [GCC 13.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import skfem
>>> mesh = skfem.Mesh.load("sphere.msh")

>>> mesh
<skfem MeshTet1 object>
  Number of elements: 50
  Number of vertices: 28
  Number of nodes: 28
  Named subdomains [# elements]: gmsh:bounding_entities [1]
```
Here, we do not see the volume and the surface tags. However, if we use `meshio`:
```Console
>>> import meshio
>>> mesh = meshio.read("sphere.msh")

>>> mesh
<meshio mesh object>
  Number of points: 28
  Number of cells:
    triangle: 50
    tetra: 50
  Cell sets: gmsh:bounding_entities
  Point data: gmsh:dim_tags
  Cell data: gmsh:physical, gmsh:geometrical
>>> mesh.cell_data_dict["gmsh:physical"]
{'triangle': array([2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
       2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
       2, 2, 2, 2, 2, 2]), 'tetra': array([1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
       1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
       1, 1, 1, 1, 1, 1])}
``` 
We can retrieve the volume and the surface tags.
>**NOTE:** for Salome `.med` files, `meshio` stores the mesh tags in `cell_tags` key in `cell_data_dict` which is absent when reading a Gmsh `.msh` file.
 
## How does the `skfem.Mesh` object looks after the fix?
```Console
>>> import skfem
>>> mesh = skfem.Mesh.load("sphere.msh")

>>> mesh
<skfem MeshTet1 object>
  Number of elements: 50
  Number of vertices: 28
  Number of nodes: 28
  Named subdomains [# elements]: 1 [50]
  Named boundaries [# facets]: 2 [50]
>>> mesh.subdomains
{1: array([ 0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16,
       17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33,
       34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49])}
>>> mesh.boundaries
{2: OrientedBoundary([  0,   1,   3,   5,   8,   9,  11,  13,  15,  18,  19,
                   21,  23,  27,  28,  30,  33,  36,  39,  42,  44,  47,
                   49,  51,  53,  57,  59,  62,  64,  67,  69,  71,  74,
                   76,  79,  81,  84,  86,  89,  90,  92,  96,  98, 100,
                  103, 105, 108, 110, 112, 115], dtype=int32)}
```
We can obtains the volume and surface tags from `subdomains` and `boundaries` attributes, respectively.

## How was this achieved?

In summary, this is possible by modifying the `from_meshio` function in `skfem/io/meshio.py` module. The following steps are taken:
- The aim is to create a `cell_index_dict` dictionary that holds the physical region tags, element type, and element indices using the form: `{region: {element type: element indices}}`.
- Attempt to read the "name" tags of subregions and boundaries from `meshio.cell_sets_dict` and add it to the `cell_index_dict`.
- If the "name" tags of the subregions are not found in `meshio.cell_sets_dict`, search for `gmsh:physical` or `cell_tags` key in the `meshio.cell_data_dict` to obtain the integer tags. If the integer tags are retrieved, add them to the `cell_index_dict`.
- Finally, create `subregions` and `boundaries` attribute for `skfem.Mesh` using the `cell_index_dict`.