### PR TITLE
fix(_intersect1D): restrict supermesh to the intersection of both x-r…

### DIFF
--- a/skfem/supermeshing.py
+++ b/skfem/supermeshing.py
@@ -69,9 +69,17 @@ def _intersect2d(p1, t1, p2, t2):
 
 def _intersect1d(p1, t1, p2, t2):
     """One-dimensional supermesh."""
-    # find unique supermesh facets by combining nodes from both sides
-    p = np.concatenate((p1.flatten().round(decimals=10),
-                        p2.flatten().round(decimals=10)))
+    # find unique supermesh facets by combining nodes from both sides in the intersection of x-ranges 
+    p1f = p1.flatten().round(decimals=10)
+    p2f = p2.flatten().round(decimals=10)
+    
+    xmin = max(p1f.min(), p2f.min())
+    xmax = min(p1f.max(), p2f.max())
+    
+    p1f = p1f[(p1f >= xmin) & (p1f <= xmax)]
+    p2f = p2f[(p2f >= xmin) & (p2f <= xmax)]
+    
+    p = np.concatenate((p1f, p2f))
     p = np.unique(p)
     t = np.array([np.arange(len(p) - 1), np.arange(1, len(p))])
     p = np.array([p])

--- a/skfem/supermeshing.py
+++ b/skfem/supermeshing.py
@@ -69,16 +69,16 @@ def _intersect2d(p1, t1, p2, t2):
 
 def _intersect1d(p1, t1, p2, t2):
     """One-dimensional supermesh."""
-    # find unique supermesh facets by combining nodes from both sides in the intersection of x-ranges 
+    # Find unique supermesh facets by combining nodes from both
+    # sides in the intersection of x-ranges.
     p1f = p1.flatten().round(decimals=10)
     p2f = p2.flatten().round(decimals=10)
-    
+
     xmin = max(p1f.min(), p2f.min())
     xmax = min(p1f.max(), p2f.max())
-    
+
     p1f = p1f[(p1f >= xmin) & (p1f <= xmax)]
     p2f = p2f[(p2f >= xmin) & (p2f <= xmax)]
-    
     p = np.concatenate((p1f, p2f))
     p = np.unique(p)
     t = np.array([np.arange(len(p) - 1), np.arange(1, len(p))])


### PR DESCRIPTION
Previously, the supermesh was built from the union of all nodes from both input meshes. When the two boundary traces had different x-ranges, the supermesh extended beyond one or both of the original meshes. The midpoints of those out-of-range supermesh elements were then passed to element_finder(), which uses np.digitize without clamping:
- points below the mesh minimum produce a bin index of 0, which matches
  no element's right-node → ValueError("Point is outside of the mesh.")
- points above the mesh maximum produce a bin index of n_nodes, causing
  an IndexError (out of bounds on the sorted index array ix).

Fix: before merging the two node arrays, clip each to the x-range shared by both meshes ([max(min_p1, min_p2), min(max_p1, max_p2)]). The supermesh then only spans the region where both boundaries overlap, so every supermesh midpoint is guaranteed to lie inside both original meshes when element_finder is called.

This also reflects the correct physical interpretation: the contact (or mortar) integral should only be evaluated over the region where the two surfaces actually overlap.