### PR TITLE
Correcting lamé parameters for plane stress model

### DIFF
--- a/skfem/models/elasticity.py
+++ b/skfem/models/elasticity.py
@@ -28,7 +28,6 @@ def lame_parameters(E, nu):
 
 def plane_stress(E, nu):
     """Map Young's modulus and Poisson ratio to plane stress lame parameters.
-    
     Parameters
     ----------
     E
@@ -38,14 +37,14 @@ def plane_stress(E, nu):
 
     Returns
     -------
-    float
+    lam: float
         The first Lamé parameter for plane stress scenario (lambda)
-    float
+    mu: float
         The second Lamé parameter for plane stress scenario (mu)
-
     """
-    return (E * nu / (1. - nu**2),
-            E / (2. * (1. + nu)))
+    lam = E * nu / (1. - nu**2)
+    mu = E / (2. * (1. + nu))
+    return (lam, mu)
 
 
 def linear_stress(Lambda=1., Mu=1.):

--- a/skfem/models/elasticity.py
+++ b/skfem/models/elasticity.py
@@ -27,9 +27,25 @@ def lame_parameters(E, nu):
 
 
 def plane_stress(E, nu):
-    """Map Young's modulus and Poisson ratio to plane stress."""
-    return (E * (1. + 2. * nu) / (1. + nu) ** 2,
-            nu / (1. + nu))
+    """Map Young's modulus and Poisson ratio to plane stress lame parameters.
+    
+    Parameters
+    ----------
+    E
+        Young's modulus
+    nu
+        Poisson ratio
+
+    Returns
+    -------
+    float
+        The first Lamé parameter for plane stress scenario (lambda)
+    float
+        The second Lamé parameter for plane stress scenario (mu)
+
+    """
+    return (E * nu / (1. - nu**2),
+            E / (2. * (1. + nu)))
 
 
 def linear_stress(Lambda=1., Mu=1.):


### PR DESCRIPTION
The former calculation of the lamé parameters lambda and mu is to the best of my understanding wrong. The updated fromulae correspond to the derivation of the lamé parameters derived from the generalized Hooks Law for sigma_zz = 0.