### PR TITLE
fix: enforce now handles rows with no nonzeros (fixes #1195)

### DIFF
--- a/skfem/utils.py
+++ b/skfem/utils.py
@@ -373,14 +373,25 @@ def enforce(A: spmatrix,
 
     Aout = A if overwrite else A.copy()
 
-    # set rows on lhs to zero
+    # Zero the rows of `Aout` whose indices are in `D`. Each such row
+    # contributes ``count[i]`` data entries to ``Aout.data``, starting at
+    # ``Aout.indptr[D[i]]``. We build the flat list of data positions to
+    # zero by repeating each row's start and adding the within-row offset
+    # ``0 .. count[i] - 1``.
+    #
+    # The previous incremental construction (cumsum/subtract) silently
+    # produced out-of-range indices when any row in ``D`` had no nonzeros
+    # (e.g. an element with only Dirichlet dofs); see issue #1195. The
+    # form below handles ``count[i] == 0`` correctly because both
+    # ``np.repeat`` and the ``np.arange`` subtraction contribute nothing
+    # for an empty row.
     start = Aout.indptr[D]
-    stop = Aout.indptr[D + 1]
-    count = stop - start
-    idx = np.ones(count.sum(), dtype=np.int32)
-    idx[np.cumsum(count)[:-1]] -= count[:-1]
-    idx = np.repeat(start, count) + np.cumsum(idx) - 1
-    Aout.data[idx] = 0.
+    count = Aout.indptr[D + 1] - start
+    if count.sum() > 0:
+        offsets = (np.arange(count.sum())
+                   - np.repeat(np.cumsum(count) - count, count))
+        idx = np.repeat(start, count) + offsets
+        Aout.data[idx] = 0.
 
     # set diagonal value
     d = Aout.diagonal()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -53,6 +53,54 @@ class TestEnforce(TestCase):
         assert_almost_equal(A.toarray(), np.eye(A.shape[0]))
 
 
+def test_enforce_handles_empty_rows():
+    """Regression: ``enforce`` must work when some enforced rows have no
+    nonzeros to begin with -- this happens whenever an assembled matrix has
+    rows belonging to elements that contribute only Dirichlet dofs (e.g.
+    a p-Laplacian Hessian whose surface dofs see no neighbours through the
+    bulk form). The previous implementation built an offset array via
+    ``np.cumsum(np.ones(...))`` and silently produced out-of-range indices
+    on any zero-row, raising ``IndexError``. See issue #1195.
+    """
+    m = MeshTri().refined(1)
+    basis = CellBasis(m, ElementTriP1())
+
+    # Build a matrix with at least one entirely-zero row among the boundary
+    # dofs by assembling a bilinear form whose coefficient vanishes
+    # everywhere -- this mirrors what happens when surface dofs end up
+    # with no in-bulk neighbours.
+    @BilinearForm
+    def zero_form(u, v, w):
+        return 0. * u * v
+
+    A = zero_form.assemble(basis)
+    D = m.boundary_nodes()
+
+    # Confirm we really have empty rows in D (otherwise the test would
+    # silently pass even with the old buggy code).
+    counts = A.indptr[D + 1] - A.indptr[D]
+    assert (counts == 0).any(), "test setup did not produce any empty rows"
+
+    Aout = enforce(A, D=D)
+
+    # Every enforced row must end up with diag = 1 and no off-diagonal
+    # nonzeros; non-enforced rows must be untouched.
+    dense = Aout.toarray()
+    for d in D:
+        row = dense[d]
+        assert row[d] == 1.0
+        row[d] = 0.0
+        assert not row.any()
+    rest = np.setdiff1d(np.arange(A.shape[0]), D)
+    assert_almost_equal(dense[rest], A.toarray()[rest])
+
+    # And with a right-hand side ``b`` the enforced entries must be set.
+    b = np.ones(A.shape[0])
+    _, bout = enforce(A, b, D=D)
+    assert_almost_equal(bout[D], 0.)
+    assert_almost_equal(bout[rest], b[rest])
+
+
 def test_simple_cg_solver():
 
     m = MeshTri().refined(3)


### PR DESCRIPTION
# Fix: `enforce` now handles rows with no nonzeros

Fixes #1195.

## Problem

`skfem.utils.enforce` zeros the rows of `A` belonging to the Dirichlet
dofs `D` by constructing a flat array of positions into `A.data`. The
previous implementation:

```python
idx = np.ones(count.sum(), dtype=np.int32)
idx[np.cumsum(count)[:-1]] -= count[:-1]
idx = np.repeat(start, count) + np.cumsum(idx) - 1
```

only works when every row in `D` has at least one stored nonzero. If any
`count[i] == 0` — which happens whenever an enforced row has no in-bulk
neighbours, e.g. a `MeshTri().refined(1)` p-Laplacian Hessian whose
surface dofs have all-zero gradient contributions — then
`np.cumsum(count)[:-1]` contains duplicate indices, the corresponding
entries in `idx` are decremented twice, and the final `idx` runs past
the end of `A.data` and raises `IndexError`.

Repro from #1195 (a p-Laplacian Hessian on a 1-refined mesh, where the
surface dofs end up with empty rows):

```python
import numpy as np, skfem as fem
from skfem.helpers import dot, grad

@fem.BilinearForm
def hessian(u, v, p):
    w = p['x']; gradw = grad(w); tmp = dot(gradw, gradw)
    plap = (4-2)*tmp**((4-4)*0.5) * dot(grad(u), gradw)*dot(gradw, grad(v))
    lap  = tmp**((4-2)*0.5)*dot(grad(u), grad(v))
    return lap + plap

mesh = fem.MeshTri().refined(1)
basis = fem.Basis(mesh, fem.ElementTriP1())
x = basis.project(lambda x: 0.02 * np.pi**2 * np.sin(np.pi*x[0]) * np.sin(np.pi*x[1]))
x[mesh.boundary_nodes()] = 0.
A = fem.asm(hessian, basis, x=basis.interpolate(x), p=4, rho=1.0)
fem.utils.enforce(A, D=mesh.boundary_nodes())
# IndexError: index 27 is out of bounds for axis 0 with size 27
```

Different from the closed #1043 (where the *entire* matrix is zero and
the result wouldn't be invertible) — here only a subset of the enforced
rows are empty and the resulting enforced system is perfectly usable.

## Fix

Rewrite the index construction to handle empty rows correctly:

```python
offsets = (np.arange(count.sum())
           - np.repeat(np.cumsum(count) - count, count))
idx = np.repeat(start, count) + offsets
```

Both `np.repeat(start, count)` and the offset arithmetic contribute
nothing when `count[i] == 0`, so the result is well-defined regardless
of how many zero-rows are in `D`. Also short-circuit when
`count.sum() == 0` (e.g. `D` is empty) to avoid scipy warnings about
zero-length fancy indexing.

## Verification

Adds `tests/test_utils.py::test_enforce_handles_empty_rows`. The test
sets up the failing scenario explicitly (a `BilinearForm` whose
coefficient is identically zero, which makes every boundary row empty)
and asserts:

- `assert (counts == 0).any()` — the test really triggers the broken
  code-path,
- enforced rows end up with `diag == 1.0` and no off-diagonal nonzeros,
- non-enforced rows are bitwise-equal to the input,
- with a right-hand side, `bout[D] == x[D]` and other entries unchanged.

Local CI (matches `.github/workflows/main.yml`):

```console
$ flake8 skfem
$ sphinx-build -a -b doctest docs docs/_build
... 188 tests, 0 failures in tests ...
$ pytest tests/test_utils.py tests/test_basis.py
======================= 87 passed, 104 warnings in 5.19s =======================
```

## Scope

Only `skfem/utils.py` (production fix) and `tests/test_utils.py`
(regression test). No public API change — `enforce`'s signature and
return contract are unchanged; the fix is purely the internal flat-index
construction.
