### PR TITLE
Fix PermissionError in mesh save/load tests on Windows (#882)

### DIFF
--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -1,3 +1,4 @@
+import os
 from unittest import TestCase
 from pathlib import Path
 
@@ -559,9 +560,16 @@ def test_saveload_cycle_vtk(m):
 
     from tempfile import NamedTemporaryFile
     m = m.refined(2)
-    with NamedTemporaryFile(suffix='.vtk') as f:
-        m.save(f.name)
-        m2 = Mesh.load(f.name)
+    # delete=False and explicit unlink: on Windows the OS keeps an exclusive
+    # lock on an open NamedTemporaryFile, so m.save() reopening the same path
+    # raises PermissionError (issue #882).
+    with NamedTemporaryFile(suffix='.vtk', delete=False) as f:
+        tmpname = f.name
+    try:
+        m.save(tmpname)
+        m2 = Mesh.load(tmpname)
+    finally:
+        os.unlink(tmpname)
 
     assert_array_equal(m.p, m2.p)
     assert_array_equal(m.t, m2.t)
@@ -609,10 +617,15 @@ def test_saveload_cycle_tags(fmt, kwargs, m, ignore_orientation, ignore_interior
          .with_boundaries({'test': lambda x: (x[0] == 0) * (x[1] < 0.6),
                            'set': lambda x: (x[0] == 0) * (x[1] > 0.3)}))
     from tempfile import NamedTemporaryFile
-    with NamedTemporaryFile(suffix=fmt) as f:
-        m.save(f.name, point_data={'foo': m.p[0]}, **kwargs)
+    # delete=False and explicit unlink: on Windows the OS keeps an exclusive
+    # lock on an open NamedTemporaryFile, so m.save() reopening the same path
+    # raises PermissionError (issue #882).
+    with NamedTemporaryFile(suffix=fmt, delete=False) as f:
+        tmpname = f.name
+    try:
+        m.save(tmpname, point_data={'foo': m.p[0]}, **kwargs)
         out = ['point_data', 'cells_dict']
-        m2 = Mesh.load(f.name,
+        m2 = Mesh.load(tmpname,
                        out=out,
                        ignore_orientation=ignore_orientation,
                        ignore_interior_facets=ignore_interior_facets)
@@ -627,6 +640,8 @@ def test_saveload_cycle_tags(fmt, kwargs, m, ignore_orientation, ignore_interior
         for key in m.boundaries:
             assert_array_equal(m2.boundaries[key].sort(),
                                m.boundaries[key].sort())
+    finally:
+        os.unlink(tmpname)
 
 
 def test_periodic_failure():


### PR DESCRIPTION
Fixes #882.

### Problem

The mesh save/load round-trip tests fail on Windows. `test_saveload_cycle_vtk`
and `test_saveload_cycle_tags` use

```python
with NamedTemporaryFile(suffix=...) as f:
    m.save(f.name)
    m2 = Mesh.load(f.name)
```

On Windows the OS keeps an **exclusive lock** on a `NamedTemporaryFile` while it
is open, so when `m.save(f.name)` (via `meshio`) reopens the same path for
writing it raises `PermissionError: [Errno 13] Permission denied`. The CI only
runs `ubuntu-latest`, so this is never exercised.

Reproduced on Windows 11 / Python 3.11: `pytest tests/test_mesh.py -k saveload`
gives 68 failures, all `PermissionError` from `meshio` reopening the locked
temp file. The library save/load code itself is correct — only the test fixture
is Windows-incompatible.

### Fix

Use the idiom suggested in the issue: open the temp file with `delete=False`,
close the handle, then write/read the path, and remove it in a `finally` block.
This is cross-platform (on Linux it simply removes the file in `finally` instead
of on context-manager exit).

### Verification

With the change, `pytest tests/test_mesh.py -k saveload` passes (68 passed), and
the full `pytest tests/test_mesh.py` shows no regressions. `flake8 skfem` is
clean. Verified on Windows 11 / Python 3.11.9.

I kept this PR to the test fix only. If a `windows-latest` entry in the CI
matrix would be welcome to prevent regressions, I am happy to add it in a
separate PR.
