### PR TITLE
Preserve continuity in `MeshTri1DG.periodic` #1216

### DIFF
--- a/skfem/mesh/mesh_dg.py
+++ b/skfem/mesh/mesh_dg.py
@@ -66,7 +66,10 @@ class MeshDG:
         oix = np.setdiff1d(np.arange(mesh.nvertices, dtype=np.int32), ix)
         remap[oix] = np.arange(mesh.nvertices - len(ix), dtype=np.int32)
 
-        doflocs = np.hstack((mesh.doflocs[:, oix], mesh.doflocs[:, ix]))
+        doflocs = np.hstack((
+            np.take(mesh.doflocs, oix, axis=1),
+            np.take(mesh.doflocs, ix, axis=1),
+        ))
         t = remap[mesh.t]
 
         reordered_mesh = replace(


### PR DESCRIPTION
Solve issue described in #1216, and keeps `doflocs` array C_CONTIGUOUS in method `MeshTri1DG.periodic`.

I could not contribute a test since the only difference from the caller perspective is the warning being printed. The only option would be to add a test that captures the warning with the `caplog` fixture, but it's not very stable. Let me know if you have other ideas.

Thanks!