### PR TITLE
Add batched interpolation of solution vectors

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -79,7 +79,7 @@ Subclasses of :class:`~skfem.assembly.basis.AbstractBasis` represent a global
 finite element basis evaluated at quadrature points.
 
 .. autoclass:: skfem.assembly.basis.AbstractBasis
-   :members: get_dofs, interpolate, project
+   :members: get_dofs, interpolate, interpolate_multiple, project
 
 Class: CellBasis
 ****************
@@ -87,7 +87,7 @@ Class: CellBasis
 .. autoclass:: skfem.assembly.Basis
 
 .. autoclass:: skfem.assembly.CellBasis
-   :members: __init__, interpolate, project
+   :members: __init__, interpolate, interpolate_multiple, project
 
 
 Class: FacetBasis

--- a/skfem/assembly/basis/abstract_basis.py
+++ b/skfem/assembly/basis/abstract_basis.py
@@ -321,6 +321,37 @@ class AbstractBasis:
             return tuple(dfs)
         return dfs[0]
 
+    def interpolate_multiple(self, w: ndarray) -> Union[ndarray,
+                                                        Tuple[ndarray, ...]]:
+        """Interpolate multiple solution vectors to quadrature points.
+
+        Parameters
+        ----------
+        w
+            An array of shape ``(N, nfields)`` whose columns are solution
+            vectors.
+
+        Returns
+        -------
+        ndarray or tuple of ndarray
+            Values of a scalar element have shape ``(nelems, nqp, nfields)``.
+            Vector or tensor component axes precede these axes.  A tuple is
+            returned for a composite element.
+
+        """
+        if w.ndim != 2 or w.shape[0] != self.N:
+            raise ValueError("Input array must have shape (N, nfields).")
+
+        values = w[self.element_dofs]
+        out = [
+            np.einsum('ief,i...eq->...eqf',
+                      values,
+                      np.asarray([b[c].get(0) for b in self.basis]),
+                      optimize=True)
+            for c in range(len(self.basis[0]))
+        ]
+        return tuple(out) if len(out) > 1 else out[0]
+
     def split_indices(self) -> List[ndarray]:
         """Return indices for the solution components."""
         output: List[ndarray] = []

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -461,6 +461,55 @@ def test_basis_interpolate_project(m, e):
     assert_almost_equal(x, X)
 
 
+@pytest.mark.parametrize(
+    "e",
+    [
+        ElementTriP2(),
+        ElementVectorH1(ElementTriP1()),
+        ElementTriP2() * ElementTriP1(),
+    ],
+)
+def test_basis_interpolate_multiple(e):
+
+    basis = CellBasis(MeshTri().refined(), e)
+    x = (np.arange(3 * basis.N).reshape(basis.N, 3)
+         * (1. + 1.j))
+    actual = basis.interpolate_multiple(x)
+    expected = [basis.interpolate(x[:, k]) for k in range(x.shape[1])]
+
+    if isinstance(actual, tuple):
+        for c, component in enumerate(actual):
+            assert_allclose(component,
+                            np.stack([y[c] for y in expected], axis=-1))
+    else:
+        assert_allclose(actual, np.stack(expected, axis=-1))
+
+
+def test_basis_interpolate_multiple_input_shape():
+
+    basis = CellBasis(MeshTri(), ElementTriP1())
+    with pytest.raises(ValueError):
+        basis.interpolate_multiple(basis.zeros())
+    with pytest.raises(ValueError):
+        basis.interpolate_multiple(np.empty((basis.N + 1, 2)))
+
+
+def test_basis_interpolate_multiple_assembly():
+
+    basis = CellBasis(MeshTri(), ElementTriP1())
+
+    @LinearForm
+    def sum_fields(v, w):
+        return np.sum(w.x, axis=-1) * v
+
+    actual = sum_fields.assemble(
+        basis,
+        x=basis.interpolate_multiple(np.ones((basis.N, 3))),
+    )
+    expected = 3. * LinearForm(lambda v, _: v).assemble(basis)
+    assert_allclose(actual, expected)
+
+
 def test_subdomain_facet_assembly():
 
     def subdomain(x):


### PR DESCRIPTION
Closes #1196.

Adds a separate `Basis.interpolate_multiple(w)` method for interpolating
column-stacked solution vectors at quadrature points using a batched
contraction.

The method accepts an array of shape `(basis.N, nfields)`. Scalar outputs have
shape `(nelems, nqp, nfields)`, while vector and tensor component axes precede
those axes. For an `ElementComposite`, it returns one array per constituent
element as a tuple.

The existing `Basis.interpolate` method and `DiscreteField` are unchanged.
This initial implementation interpolates values only; derivative selection and
a reusable sparse operator remain outside the scope.

## Performance

In a local benchmark using the Tet P2 setup from #1196 with 100 complex fields:

| Method | Time |
|---|---:|
| `interpolate_multiple` | 5.6 ms |
| 100 calls to `interpolate` | 433 ms |